### PR TITLE
Use numbers rather than string manipulation for BigDecimal encoding

### DIFF
--- a/pg-core/src/java/org/pg/codec/NumericBin.java
+++ b/pg-core/src/java/org/pg/codec/NumericBin.java
@@ -1,48 +1,41 @@
 package org.pg.codec;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class NumericBin {
+
+    private static final int DECIMAL_DIGITS = 4;
+    private static final BigInteger TEN_THOUSAND = new BigInteger("10000");
 
     private final static int NUMERIC_POS = 0x0000;
     private final static int NUMERIC_NEG = 0x4000;
     private final static int NUMERIC_NAN = 0xC000;
 
     public static ByteBuffer encode(final BigDecimal value) {
-        final int scale = value.scale();
-        final String[] parts = value.toPlainString().split("\\.");
-        final String lead = parts[0];
-        final boolean isNegative = lead.startsWith("-");
-        final String hi = isNegative ? lead.substring(1) : lead;
-        final String lo = parts.length > 1 ? parts[1] : "";
-        final int hiLen = hi.length();
-        final int loLen = lo.length();
-        final int sign = isNegative ? NUMERIC_NEG : NUMERIC_POS;
-        final int weight = hiLen / 4;
-        final int padLeft = 4 - hiLen % 4;
-        final int padRight = 4 - (padLeft + hiLen + loLen) % 4;
-        final String digitsStr = "0".repeat(padLeft) + hi + lo + "0".repeat(padRight);
-        final int digitsNum = digitsStr.length() / 4;
-        final short[] shorts = new short[digitsNum];
+        // Number of fractional digits:
+        final int fractionDigits = value.scale();
 
-        for (int i = 0; i < digitsNum; i++) {
-            int idxStart = i * 4;
-            int idxEnd = idxStart + 4;
-            String part = digitsStr.substring(idxStart, idxEnd);
-            shorts[i] = Short.parseShort(part);
-        }
+        // Number of Fraction Groups:
+        final int fractionGroups = fractionDigits > 0 ? (fractionDigits + 3) / 4 : 0;
 
-        final int bbLen = 8 + 2 * digitsNum;
+        final List<Integer> digits = digits(value);
+
+        final int bbLen = 8 + (2 * digits.size());
         final ByteBuffer bb = ByteBuffer.allocate(bbLen);
-        bb.putShort((short) digitsNum);
-        bb.putShort((short) weight);
-        bb.putShort((short) sign);
-        bb.putShort((short) scale);
 
-        for (final Short sh: shorts) {
-            bb.putShort(sh);
+        bb.putShort((short) digits.size());
+        bb.putShort((short) (digits.size() - fractionGroups - 1));
+        bb.putShort((short) (value.signum() == 1 ? NUMERIC_POS : NUMERIC_NEG));
+        bb.putShort((short) (fractionDigits > 0 ? fractionDigits : 0));
+
+        for (int pos = digits.size() - 1; pos >= 0; pos--) {
+            final int valueToWrite = digits.get(pos);
+            bb.putShort((short) valueToWrite);
         }
 
         return bb;
@@ -75,11 +68,53 @@ public final class NumericBin {
                 .setScale(scale, RoundingMode.DOWN);
     }
 
+    // Inspired by implementation here:
+    // https://github.com/PgBulkInsert/PgBulkInsert/blob/master/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/pgsql/handlers/BigDecimalValueHandler.java
+    private static List<Integer> digits(final BigDecimal value) {
+        BigInteger unscaledValue = value.unscaledValue();
+
+        if (value.signum() == -1) {
+            unscaledValue = unscaledValue.negate();
+        }
+
+        final List<Integer> digits = new ArrayList<>();
+
+        if (value.scale() > 0) {
+            // The scale needs to be a multiple of 4:
+            int scaleRemainder = value.scale() % 4;
+
+            // Scale the first value:
+            if (scaleRemainder != 0) {
+                final BigInteger[] result = unscaledValue.divideAndRemainder(BigInteger.TEN.pow(scaleRemainder));
+                final int digit = result[1].intValue() * (int) Math.pow(10, DECIMAL_DIGITS - scaleRemainder);
+                digits.add(digit);
+                unscaledValue = result[0];
+            }
+
+            while (!unscaledValue.equals(BigInteger.ZERO)) {
+                final BigInteger[] result = unscaledValue.divideAndRemainder(TEN_THOUSAND);
+                digits.add(result[1].intValue());
+                unscaledValue = result[0];
+            }
+        } else {
+            BigInteger originalValue = unscaledValue.multiply(BigInteger.TEN.pow(Math.abs(value.scale())));
+            while (!originalValue.equals(BigInteger.ZERO)) {
+                final BigInteger[] result = originalValue.divideAndRemainder(TEN_THOUSAND);
+                digits.add(result[1].intValue());
+                originalValue = result[0];
+            }
+        }
+
+        return digits;
+    }
+
     public static void main (final String[] args) {
-        final ByteBuffer bb = encode(new BigDecimal("1"));
+        String arg = args.length > 0 ? args[0] : "1";
+        BigDecimal num = new BigDecimal(arg);
+        final ByteBuffer bb = encode(num);
         bb.rewind();
-        // System.out.println(Arrays.toString(encodeBin(new BigDecimal("1")).array()));
         System.out.println(decode(bb));
+        //System.out.println(java.util.Arrays.toString(encode(num).array()));
     }
 
 }

--- a/pg-core/test/pg/encode_bin_test.clj
+++ b/pg-core/test/pg/encode_bin_test.clj
@@ -176,7 +176,8 @@
   ;; bigint
 
   (let [res (pg/encode-bin (bigint 1) oid/numeric)]
-    (is (bb== (byte-array [0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0]) res)))
+    (is (= [0, 1, 0, 0, 0, 0, 0, 0, 0, 1] (vec (.array res))))
+    )
 
   (let [res (pg/encode-bin (bigint 1) oid/int2)]
     (is (bb== (byte-array [0 1]) res)))
@@ -190,7 +191,7 @@
   ;; biginteger
 
   (let [res (pg/encode-bin (new BigInteger "1") oid/numeric)]
-    (is (bb== (byte-array [0, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0]) res)))
+    (is (bb== (byte-array [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]) res)))
 
   (let [res (pg/encode-bin (new BigInteger "1") oid/int2)]
     (is (bb== (byte-array [0 1]) res)))


### PR DESCRIPTION
Thanks for the library! It's great!

There were a couple small things that I found with the numeric binary encoding, and those are addressed here:

1. An extra "group" was included for some numbers that was zero-padded. Sending the number "1" as effectively "1.0000" once you decode all the groups of shorts. This may be interpreted okay by the server, but it's extra bytes that aren't necessary.
2. Other folks already figured out a nice quick implementation for breaking out the fractional groups, and it doesn't rely on string representations.