### PR TITLE
(EDIT) Use executors for asynchronous messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## 0.1.32-SNAPSHOT
 
-- ?
+- #32 introduce :executor connection option for async messages @jgdavey
 
 ## 0.1.31
 

--- a/pg-core/src/clj/pg/core.clj
+++ b/pg-core/src/clj/pg/core.clj
@@ -43,6 +43,7 @@
    org.pg.enums.TxLevel
    org.pg.error.PGError
    org.pg.error.PGErrorResponse
+   org.pg.PgExecutors
    org.pg.json.JSON
    org.pg.json.JSON$Wrapper
    org.pg.processor.IProcessor
@@ -53,6 +54,11 @@
 (def ^CopyFormat COPY_FORMAT_CSV CopyFormat/CSV)
 (def ^CopyFormat COPY_FORMAT_TAB CopyFormat/TAB)
 
+(def built-in-executors
+  {:default clojure.lang.Agent/soloExecutor
+   :future clojure.lang.Agent/soloExecutor
+   :threadpool PgExecutors/threadPoolExecutor
+   :direct PgExecutors/directExecutor})
 
 (defn ->kebab
   "
@@ -324,6 +330,7 @@
                 fn-notification
                 fn-protocol-version
                 fn-notice
+                executor
 
                 ;; ssl
                 use-ssl? ;; deprecated
@@ -420,6 +427,9 @@
 
       fn-notice
       (.fnNotice fn-notice)
+
+      executor
+      (.executor (get built-in-executors executor executor))
 
       (some? so-keep-alive?)
       (.SOKeepAlive so-keep-alive?)

--- a/pg-core/src/java/org/pg/Config.java
+++ b/pg-core/src/java/org/pg/Config.java
@@ -2,6 +2,7 @@ package org.pg;
 
 import clojure.lang.IFn;
 import clojure.lang.Named;
+import clojure.lang.Agent;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.pg.enums.ConnType;
 import org.pg.enums.SSLValidation;
@@ -15,6 +16,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 
 public record Config(
         String user,
@@ -37,6 +39,7 @@ public record Config(
         IFn fnNotification,
         IFn fnProtocolVersion,
         IFn fnNotice,
+        Executor executor,
         SSLContext sslContext,
         SSLValidation sslValidation,
         long cancelTimeoutMs,
@@ -89,6 +92,7 @@ public record Config(
         private IFn fnNotification;
         private IFn fnProtocolVersion;
         private IFn fnNotice;
+        private Executor executor = Agent.soloExecutor;
         private SSLContext sslContext = null;
         private SSLValidation sslValidation = Const.SSL_VALIDATION;
         private long cancelTimeoutMs = Const.MS_CANCEL_TIMEOUT;
@@ -205,6 +209,15 @@ public record Config(
             this.fnProtocolVersion = Objects.requireNonNull(
                     fnProtocolVersion,
                     "Protocol version function cannot be null"
+            );
+            return this;
+        }
+
+        @SuppressWarnings("unused")
+        public Builder executor(final Executor executor) {
+            this.executor = Objects.requireNonNull(
+                executor,
+                "executor cannot be null"
             );
             return this;
         }
@@ -364,6 +377,7 @@ public record Config(
                     this.fnNotification,
                     this.fnProtocolVersion,
                     this.fnNotice,
+                    this.executor,
                     this.sslContext,
                     this.sslValidation,
                     this.cancelTimeoutMs,

--- a/pg-core/src/java/org/pg/PgExecutors.java
+++ b/pg-core/src/java/org/pg/PgExecutors.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class PgExecutors {
     final private static AtomicLong cachedThreadPoolCounter = new AtomicLong(0);
+    final private static System.Logger logger = System.getLogger(PgExecutors.class.getCanonicalName());
 
     @SuppressWarnings("unused")
     volatile public static Executor directExecutor = new DirectExecutor();
@@ -34,7 +35,11 @@ public class PgExecutors {
 
     private static class DirectExecutor implements Executor {
         public void execute(Runnable r) {
-            r.run();
+            try {
+                r.run();
+            } catch (Exception e) {
+                logger.log(System.Logger.Level.WARNING, "Uncaught exception while executing async message", e);
+            }
         }
     }
 

--- a/pg-core/src/java/org/pg/PgExecutors.java
+++ b/pg-core/src/java/org/pg/PgExecutors.java
@@ -1,0 +1,44 @@
+package org.pg;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class PgExecutors {
+    final private static AtomicLong cachedThreadPoolCounter = new AtomicLong(0);
+
+    @SuppressWarnings("unused")
+    volatile public static Executor directExecutor = new DirectExecutor();
+
+    @SuppressWarnings("unused")
+    volatile public static ExecutorService threadPoolExecutor = new ThreadPoolExecutor(
+        1,
+        Runtime.getRuntime().availableProcessors(),
+        60L, TimeUnit.SECONDS,
+        new LinkedBlockingQueue<Runnable>(),
+        createThreadFactory("pg2-pool-%d", cachedThreadPoolCounter));
+
+    private static ThreadFactory createThreadFactory(final String format, final AtomicLong threadPoolCounter) {
+        return new ThreadFactory() {
+            public Thread newThread(Runnable runnable) {
+                Thread thread = new Thread(runnable);
+                thread.setName(String.format(format, threadPoolCounter.getAndIncrement()));
+                return thread;
+            }
+        };
+    }
+
+    private static class DirectExecutor implements Executor {
+        public void execute(Runnable r) {
+            r.run();
+        }
+    }
+
+    public static void shutdown(){
+        threadPoolExecutor.shutdown();
+    }
+}

--- a/pg-core/test/pg/integration.clj
+++ b/pg-core/test/pg/integration.clj
@@ -71,6 +71,9 @@
       (testing (format "PORT %s" port)
         (t)))))
 
+(def has-virtual-threads?
+  (>= (.feature (Runtime/version)) 21))
+
 
 (defn is11? []
   (= *PORT* P11))


### PR DESCRIPTION
Always using the Clojure soloExecutor has a few limitations:

* There's no way to ensure sequential message handling since the executor will run Threads concurrently.
* It co-locates these message callback executions with Clojure's futures (and, to a lesser extent, agents called with `send-off`)

Calling the function directly allows the user to decide to dispatch the message, i.e. via Thread, ThreadPool, core.async, or even directly (on the same Thread).

This commit also avoids building the message Clojure map unless the message handler fn is present.