### PR TITLE
Add jdbc connection uri support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## 0.1.31-SNAPSHOT
 
-- ?
+- #34 add basic JDBC URL support via :connection-uri @jgdavey
 
 ## 0.1.30
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ tests][tests].
 - [Benchmarks](/docs/benchmarks.md)
 - [Authentication](/docs/authentication.md)
 - [Connecting to the Server](/docs/connecting.md)
+- [URI Connection String](/docs/connection-uri.md)
 - [Query and Execute](/docs/query-execute.md)
 - [Prepared Statements](/docs/prepared-statement.md)
 - [Prepared Statement Cache](docs/prepared-statement-cache.md)

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -1,4 +1,4 @@
-# Connecting to the server
+# Connecting to the Server
 
 To connect the server, define a config map and pass it into the `connect`
 function:
@@ -84,6 +84,7 @@ rest have predefined values.
 |------------------------|--------------|--------------------|---------------------------------------------------------------------------------|
 | `:user`                | string       | **required**       | the name of the DB user                                                         |
 | `:database`            | string       | **required**       | the name of the database                                                        |
+| `:connection-uri`      | string       | nil                | A URI string with a user, database, and other parameters<sup>1</sup>            |
 | `:host`                | string       | 127.0.0.1          | IP or hostname                                                                  |
 | `:port`                | integer      | 5432               | port number                                                                     |
 | `:password`            | string       | ""                 | DB user password                                                                |
@@ -96,12 +97,12 @@ rest have predefined values.
 | `:fn-notification`     | 1-arg fn     | logging fn         | A function to handle notifications                                              |
 | `:fn-protocol-version` | 1-arg fn     | logging fn         | A function to handle negotiation version protocol event                         |
 | `:fn-notice`           | 1-arg fn     | logging fn         | A function to handle notices                                                    |
-| `:ssl?`                | bool         | false              | Whether to use an SSL connection<sup>1</sup>                                    |
-| `:use-ssl?`            | bool         | false              | **Deprecated:** an outdated version of `:ssl?`                                   |
-| `:ssl-validation`      | mixed        | nil                | How (and if) to validate SSL certificates<sup>1</sup>                           |
-| `:ssl-context`         | SSLContext   | nil                | An custom instance of `SSLContext` class to wrap a socket<sup>1</sup>           |
-| `:unix-socket?`        | bool         | false              | Whether to connect to a Unix domain socket<sup>2</sup>                          |
-| `:unix-socket-path`    | string       | null               | A custom path to Unix domain socket<sup>2</sup>                                 |
+| `:ssl?`                | bool         | false              | Whether to use an SSL connection<sup>2</sup>                                    |
+| `:use-ssl?`            | bool         | false              | **Deprecated:** an outdated version of `:ssl?`                                  |
+| `:ssl-validation`      | mixed        | nil                | How (and if) to validate SSL certificates<sup>2</sup>                           |
+| `:ssl-context`         | SSLContext   | nil                | An custom instance of `SSLContext` class to wrap a socket<sup>2</sup>           |
+| `:unix-socket?`        | bool         | false              | Whether to connect to a Unix domain socket<sup>3</sup>                          |
+| `:unix-socket-path`    | string       | null               | A custom path to Unix domain socket<sup>3</sup>                                 |
 | `:so-keep-alive?`      | bool         | true               | Socket KeepAlive value                                                          |
 | `:so-tcp-no-delay?`    | bool         | true               | Socket TcpNoDelay value                                                         |
 | `:so-timeout`          | integer      | 15.000             | Socket timeout value, in ms                                                     |
@@ -111,8 +112,9 @@ rest have predefined values.
 | `:protocol-version`    | integer      | 196608             | Postgres protocol version                                                       |
 | `:object-mapper`       | ObjectMapper | JSON.defaultMapper | An instance of ObjectMapper for custom JSON processing (see the "JSON" section) |
 
-1. See the [SSL Setup](/docs/ssl.md) section.
-2. See the [Unix Domain Socket](/docs/unix-socket.md) section.
+1. See the [URI Connection String](/docs/connection-uri.md) section.
+2. See the [SSL Setup](/docs/ssl.md) section.
+3. See the [Unix Domain Socket](/docs/unix-socket.md) section.
 
 ### Parameter notes
 

--- a/docs/connection-uri.md
+++ b/docs/connection-uri.md
@@ -1,0 +1,166 @@
+# URI Connection String
+
+Is it possible to specify most of connection parameters using a URI string. It
+reminds Connection URI in JDBC but with minor differences. A URI is useful when
+you cannot pass a structured data like JSON or EDN.
+
+A URI might carry a username, a password, a host, a port, and a database name. A
+query string also passes additional parameters. Here is an example of a URI
+string:
+
+~~~text
+jdbc:postgresql://fred:secret@localhost:5432/test?ssl=true
+~~~
+
+Above, the `jdbc:` prefix is ignored; it is for compatibility with JDBC
+only. When parsed, the URI becomes a map like this:
+
+~~~clojure
+{:user "fred"
+ :password "secret"
+ :host "localhost"
+ :port 5432
+ :database "test"
+ :ssl? true}
+~~~
+
+Most of the fields can be skipped or overridden with a query string. For
+example, both `user` and `password` fields can be specified like this:
+
+~~~text
+jdbc:postgresql://localhost:5432/test?ssl=true?user=ivan&password=secret123
+~~~
+
+To connect using a URI, pass it under the `:connection-uri` parameter as
+follows:
+
+~~~clojure
+(def URI "postgresql://test:test@127.0.0.1:5432/test?ssl=false")
+
+(pg/with-conn [conn {:connection-uri URI}]
+  (let [res (pg/query conn "select 1 as num")]
+    ...))
+~~~
+
+The top-level options override values from a URI. For example, it's unsafe to
+pass the password in URI. It's better to submit it through a dedicated
+`:password` top-level field:
+
+~~~clojure
+(def URI "postgresql://ivan@127.0.0.1:5432/test?ssl=false")
+
+(pg/with-conn [conn {:connection-uri URI
+                     :password (System/getenv "DB_PASSWORD")}]
+  (let [res (pg/query conn "select 1 as num")]
+    ...))
+~~~
+
+## Query Parameters
+
+This table lists query parameters supported by URI. They act like the standard
+configuration options described in the [Connecting to the
+Server](/docs/connecting.md) section with some minor differences in names
+(e.g. "boolean?" names don't have a question mark at the end).
+
+Before you read, here is a brief description of types and parsing agreements.
+
+- **boolean** values are passed as `true`, `on`, `1`, `yes` for true, and
+  `false`, `off`, `0`, `no` for false, for example `read-only=true` or
+  `read-only=off`;
+
+- **long** values are passed as a group of numbers: `so-timeout=5000`;
+
+- **reference** values must be fully qualified strings pointing to a certain
+  Clojure definition, for example:
+
+  ~~~
+  fn-notification=com.acme.server/my-handler
+  ~~~
+
+  The `com.acme.server/my-handler` string gets transformed into a symbol first,
+  and then passed to the `requiring-resolve` function that returns a Clojure
+  variable. It also loads a namepsace if it was not loaded before. Passing a
+  string that points to non-existing object will cause an exception.
+
+- **nested** means nested maps, for example: `foo.bar=1&foo.kek=2`. This
+  expression becomes `{:foo {:bar 1 :kek 2}}` when parsed. Each parameter is
+  split with a dot on a vector of lexems, and each vector is passed into the
+  `assoc-in` function in a loop. So far, only one group of parameters rely on
+  nesting (see below).
+
+| Parameter                     | Parsed as | Comment                                                    |
+|-------------------------------|-----------|------------------------------------------------------------|
+| `read-only`                   | bool      | True if make connection always read only                   |
+| `so-keep-alive`               | bool      | Enable the standard "keep alive" socket option             |
+| `so-tcp-no-delay`             | bool      | Enable the standard "no delay" socket option               |
+| `so-timeout`                  | long      | Long value for the standard "timeout" socket option        |
+| `so-recv-buf-size`            | long      | Socket receive buffer size                                 |
+| `so-send-buf-size`            | long      | Socket send buffer size                                    |
+| `binary-encode`               | bool      | Whether to use binary encoding                             |
+| `binary-decode`               | bool      | Whether to use binary decoding                             |
+| `in-stream-buf-size`          | long      | `BufferedInputStream` default size                         |
+| `out-stream-buf-size`         | long      | `BufferedOutputStream` default size                        |
+| `ssl`                         | bool      | Whether to use SSL connection                              |
+| `ssl-context`                 | ref       | A reference to a custom `SSLContext` object                |
+| `fn-notification`             | ref       | A reference to a function handling notifications           |
+| `fn-protocol-version`         | ref       | A reference to a function handling protocol mismatch event |
+| `fn-notice`                   | ref       | A reference to a function handling notices                 |
+| `cancel-timeout-ms`           | long      | A custom timeout duration when cancelling queries          |
+| `protocol-version`            | long      | A custom protocol version                                  |
+| `object-mapper`               | ref       | A reference to custom JSON `ObjectMapper` instance         |
+| `pool-min-size`               | long      | Minimum pool connection size                               |
+| `pool-max-size`               | long      | Maximum pool connection size                               |
+| `pool-expire-threshold-ms`    | long      | Pool connection expire lifetime                            |
+| `pool-borrow-conn-timeout-ms` | long      | How long to wait when borrowing a connection from a pool   |
+| `with-pgvector`               | bool      | Parse vector types provided by the `pgvector` extension    |
+| `pg-params`                   | nested    | A nested map of Postgres runtime parameters (see below)    |
+
+## JDBC Compatible Parameters
+
+[jdbc-uri]: https://jdbc.postgresql.org/documentation/use/
+
+The following parameters are borrowed from the official [JDBC URI
+specification][jdbc-uri] and act like aliases:
+
+| JDBC Parameter        | Alias for                                        |
+|-----------------------|--------------------------------------------------|
+| `readOnly`            | `read-only`                                      |
+| `connectTimeout`      | `so-timeout`                                     |
+| `ApplicationName`     | `pg-params.application_name`                     |
+| `cancelSignalTimeout` | `cancel-timeout-ms`                              |
+| `binaryTransfer`      | Enables both `binary-encode` and `binary-decode` |
+| `tcpKeepAlive`        | `so-keep-alive`                                  |
+| `tcpNoDelay`          | `so-tcp-no-delay`                                |
+| `protocolVersion`     | `protocol-version`                               |
+
+## Postgres Runtime Parameters (pg-params)
+
+The `pg-params` option represents a map of Postgres runtime settings. These
+settings apply to the current connection only and do not affect global server
+configuration.
+
+[runtime]: https://www.postgresql.org/docs/current/runtime-config.html
+
+Each option should be passes as follows:
+
+~~~
+pg-param.<setting1>=<value1>&pg-param.<setting2>=<value2>...
+~~~
+
+where
+
+- `settingN` is a name of a setting, e.g. `application_name`, or
+  `default_transaction_read_only`, or something else. It should exactly match
+  the name of a Postgres runtime parameter, e.g. keep underscores;
+
+- `valueN` is a value of a runtime parameter, e.g. a string or a number, or a
+  comma-separated list.
+
+Example:
+
+~~~
+pg-param.application_name=my-super-app&pg-param.default_transaction_read_only=off
+~~~
+
+For more details, take a look at the [list of Postgres runtime
+parameters][runtime] supported.

--- a/pg-core/src/clj/pg/connection_uri.clj
+++ b/pg-core/src/clj/pg/connection_uri.clj
@@ -1,0 +1,145 @@
+(ns pg.connection-uri
+  (:require
+   [clojure.string :as str])
+  (:import
+   (java.net URI)))
+
+(set! *warn-on-reflection* true)
+
+(defmacro error! [template & args]
+  `(throw (new Exception (format ~template ~@args))))
+
+(defn parse-query-bool ^Boolean [^String line]
+  (case (str/lower-case line)
+    "" nil
+    ("true" "on" "1" "yes") true
+    ("false" "off" "0" "no") false
+    (error! "cannot parse boolean value: %s" line)))
+
+(defn parse-query-long ^Long [^String line]
+  (case line
+    "" nil
+    (try
+      (Long/parseLong line)
+      (catch Exception e
+        (error! "cannot parse long value: %s, reason: %s"
+          line (ex-message e))))))
+
+(defn parse [^String connection-uri]
+  (let [connection-uri
+        (cond-> connection-uri
+          (str/starts-with? connection-uri "jdbc:postgresql:")
+          (subs 5))
+
+        uri
+        (new URI connection-uri)
+
+        host
+        (.getHost uri)
+
+        port
+        (.getPort uri)
+
+        port
+        (cond-> port
+          (= -1 port)
+          (do nil))
+
+        user-info
+        (.getUserInfo uri)
+
+        path
+        (.getPath uri)
+
+        database
+        (cond-> path
+          (str/starts-with? path "/")
+          (subs 1))
+
+        query
+        (.getQuery uri)
+
+        query-args
+        (when query
+          (as-> query *
+            (str/split * #"&")
+            (mapcat #(str/split % #"=" 2) *)))
+
+        _
+        (when (-> query-args count even? not)
+          (error! "malformed query params: %s" query))
+
+        query-params
+        (apply hash-map query-args)
+
+        {:strs [read-only
+
+                ;; socket options
+                so-keep-alive
+                so-tcp-no-delay
+                so-timeout
+                so-recv-buf-size
+                so-send-buf-size
+
+                ;; bin/text
+                binary-encode
+                binary-decode
+
+                ;; i
+                in-stream-buf-size
+                out-stream-buf-size
+
+
+                ;; ssl
+                ssl
+
+                ;; TODO: ssl certs for ssl context?
+
+
+                ;; TODO: unix:// or file:// scheme for unix socket?
+                ;; unix-socket
+                ;; unix-socket-path
+
+                ;; misc
+                cancel-timeout-ms
+                protocol-version
+
+                ;; pool
+                pool-min-size
+                pool-max-size
+                pool-expire-threshold-ms
+                pool-borrow-conn-timeout-ms
+
+                ;; types
+                with-pgvector?
+
+                ]}
+
+        query-params
+
+        [user password]
+        (when user-info
+          (str/split user-info #":" 2))]
+
+    {;; common fields
+     :host host
+     :port port
+     :user user
+     :password password
+     :database database
+
+     ;; params
+     :use-ssl?
+     (some-> ssl parse-query-bool)
+
+     :so-keep-alive?
+     (some-> so-keep-alive parse-query-bool)
+
+     }
+
+
+    )
+
+
+
+  )

--- a/pg-core/src/clj/pg/connection_uri.clj
+++ b/pg-core/src/clj/pg/connection_uri.clj
@@ -9,27 +9,38 @@
 (defmacro error! [template & args]
   `(throw (new Exception (format ~template ~@args))))
 
+(def non-nil-entries-xf
+  (keep (fn [entry] (when (some? (val entry)) entry))))
+
+(defmacro coalesce-fn
+  "Evaluates (f expr) in exprs one at a time, from left to right. If a
+  form returns a non-nil, returns that value and doesn't evaluate
+  any of the other expressions"
+  ([_] nil)
+  ([f x & next]
+   `(let [x# (~f ~x)]
+      (if (some? x#) x# (coalesce-fn ~f ~@next)))))
+
 (defn parse-query-bool ^Boolean [^String line]
-  (case (str/lower-case line)
-    "" nil
-    ("true" "on" "1" "yes") true
-    ("false" "off" "0" "no") false
-    (error! "cannot parse boolean value: %s" line)))
+  (when line
+    (case (str/lower-case line)
+      "" nil
+      ("true" "on" "1" "yes") true
+      ("false" "off" "0" "no") false
+      (error! "cannot parse boolean value: %s" line))))
 
 (defn parse-query-long ^Long [^String line]
-  (case line
-    "" nil
-    (try
-      (Long/parseLong line)
-      (catch Exception e
-        (error! "cannot parse long value: %s, reason: %s"
-          line (ex-message e))))))
+  (when line
+    (case line
+      "" nil
+      (try
+        (Long/parseLong line)
+        (catch Exception e
+          (error! "cannot parse long value: %s, reason: %s"
+                  line (ex-message e)))))))
 
 (defn parse [^String connection-uri]
-  (let [connection-uri
-        (cond-> connection-uri
-          (str/starts-with? connection-uri "jdbc:postgresql:")
-          (subs 5))
+  (let [connection-uri (str/replace-first connection-uri #"^jdbc:" "")
 
         uri
         (new URI connection-uri)
@@ -40,16 +51,13 @@
         port
         (.getPort uri)
 
-        port
-        (cond-> port
-          (= -1 port)
-          (do nil))
+        port (when (pos? port) port)
 
         user-info
         (.getUserInfo uri)
 
         path
-        (.getPath uri)
+        (str (.getPath uri))
 
         database
         (cond-> path
@@ -72,7 +80,18 @@
         query-params
         (apply hash-map query-args)
 
+        [user password]
+        (when user-info
+          (str/split user-info #":" 2))
+
+        user
+        (get query-params "user" (not-empty user))
+
+        password
+        (get query-params "password" (not-empty password))
+
         {:strs [read-only
+                options
 
                 ;; socket options
                 so-keep-alive
@@ -85,16 +104,14 @@
                 binary-encode
                 binary-decode
 
-                ;; i
+                ;; streams
                 in-stream-buf-size
                 out-stream-buf-size
-
 
                 ;; ssl
                 ssl
 
                 ;; TODO: ssl certs for ssl context?
-
 
                 ;; TODO: unix:// or file:// scheme for unix socket?
                 ;; unix-socket
@@ -111,35 +128,47 @@
                 pool-borrow-conn-timeout-ms
 
                 ;; types
-                with-pgvector?
+                ;with-pgvector?
 
-                ]}
-
+                ;; JDBC URI compatibility
+                readOnly
+                ApplicationName
+                cancelSignalTimeout
+                binaryTransfer
+                tcpKeepAlive
+                tcpNoDelay
+                protocolVersion]}
         query-params
 
-        [user password]
-        (when user-info
-          (str/split user-info #":" 2))]
+        config
+        {;; common fields
+         :host host
+         :port port
+         :user user
+         :password password
+         :database database
+         :use-ssl? (some? ssl)
+         :binary-decode? (coalesce-fn parse-query-bool binary-decode binaryTransfer)
+         :binary-encode? (coalesce-fn parse-query-bool binary-encode binaryTransfer)
+         :cancel-timeout-ms (coalesce-fn parse-query-long cancel-timeout-ms cancelSignalTimeout)
+         :in-stream-buf-size (parse-query-long in-stream-buf-size)
+         :out-stream-buf-size (parse-query-long out-stream-buf-size)
+         :pool-borrow-conn-timeout-ms (parse-query-long pool-borrow-conn-timeout-ms)
+         :pool-expire-threshold-ms (parse-query-long pool-expire-threshold-ms)
+         :pool-max-size (parse-query-long pool-max-size)
+         :pool-min-size (parse-query-long pool-min-size)
+         :protocol-version (coalesce-fn parse-query-long protocol-version protocolVersion)
+         :read-only? (coalesce-fn parse-query-bool read-only readOnly)
+         :so-keep-alive? (coalesce-fn parse-query-bool so-keep-alive tcpKeepAlive)
+         :so-recv-buf-size (parse-query-long so-recv-buf-size)
+         :so-send-buf-size (parse-query-long so-send-buf-size)
+         :so-tcp-no-delay? (coalesce-fn parse-query-bool so-tcp-no-delay tcpNoDelay)
+         :so-timeout (parse-query-long so-timeout)
+         :pg-params (cond-> {}
+                      options
+                      (assoc "options"  options)
 
-    {;; common fields
-     :host host
-     :port port
-     :user user
-     :password password
-     :database database
+                      ApplicationName
+                      (assoc "application_name" ApplicationName))}]
 
-     ;; params
-     :use-ssl?
-     (some-> ssl parse-query-bool)
-
-     :so-keep-alive?
-     (some-> so-keep-alive parse-query-bool)
-
-     }
-
-
-    )
-
-
-
-  )
+    (into {} non-nil-entries-xf config)))

--- a/pg-core/src/clj/pg/connection_uri.clj
+++ b/pg-core/src/clj/pg/connection_uri.clj
@@ -1,4 +1,9 @@
 (ns pg.connection-uri
+  "
+  Links:
+  - https://jdbc.postgresql.org/documentation/use/
+  "
+  (:refer-clojure :exclude [parse-long])
   (:require
    [clojure.string :as str])
   (:import
@@ -9,38 +14,66 @@
 (defmacro error! [template & args]
   `(throw (new Exception (format ~template ~@args))))
 
-(def non-nil-entries-xf
-  (keep (fn [entry] (when (some? (val entry)) entry))))
+(defn parse-bool ^Boolean [^String line]
+  (case (str/lower-case line)
+    ("true" "on" "1" "yes") true
+    ("false" "off" "0" "no") false
+    (error! "cannot parse boolean value: %s" line)))
 
-(defmacro coalesce-fn
-  "Evaluates (f expr) in exprs one at a time, from left to right. If a
-  form returns a non-nil, returns that value and doesn't evaluate
-  any of the other expressions"
-  ([_] nil)
-  ([f x & next]
-   `(let [x# (~f ~x)]
-      (if (some? x#) x# (coalesce-fn ~f ~@next)))))
+(defn parse-long ^Long [^String line]
+  (try
+    (Long/parseLong line)
+    (catch Exception e
+      (error! "cannot parse long value: %s, reason: %s"
+        line (ex-message e)))))
 
-(defn parse-query-bool ^Boolean [^String line]
-  (when line
-    (case (str/lower-case line)
-      "" nil
-      ("true" "on" "1" "yes") true
-      ("false" "off" "0" "no") false
-      (error! "cannot parse boolean value: %s" line))))
+(defn parse-ref [^String line]
+  (try
+    (-> line
+        symbol
+        requiring-resolve
+        (or (error! "reference not found: %s" line))
+        deref)
+    (catch Exception e
+      (error! "cannot resolve a reference: %s, reason: %s"
+        line (ex-message e)))))
 
-(defn parse-query-long ^Long [^String line]
-  (when line
-    (case line
-      "" nil
-      (try
-        (Long/parseLong line)
-        (catch Exception e
-          (error! "cannot parse long value: %s, reason: %s"
-                  line (ex-message e)))))))
+(defn parse-query-string
+  "
+  Parse a decoded query string line into a Clojure map.
+  Arguments with dots are treated as nested maps, e.g.:
 
-(defn parse [^String connection-uri]
-  (let [connection-uri (str/replace-first connection-uri #"^jdbc:" "")
+  name=test&params.id=123 ->
+  {'name' 'test', 'params' {'id' '123'}}
+  "
+  [^String line]
+  (when-not (str/blank? line)
+    (let [key=vals
+          (str/split (str/trim line) #"&")]
+
+      (->> key=vals
+           (map
+            (fn [key=val]
+              (str/split key=val #"=" 2)))
+           (remove
+            (fn [[_key val]]
+              (or (= val "") (= val nil))))
+           (map
+            (fn [[key val]]
+              [(str/split key #"\.") val]))
+           (reduce
+            (fn [acc [path val]]
+              (assoc-in acc path val))
+            nil)))))
+
+(defn parse
+  "
+  Parse a string URI into a map of Config options.
+  See `pg.core/->config`.
+  "
+  [^String connection-uri]
+  (let [connection-uri
+        (str/replace-first connection-uri #"^jdbc:" "")
 
         uri
         (new URI connection-uri)
@@ -51,7 +84,8 @@
         port
         (.getPort uri)
 
-        port (when (pos? port) port)
+        port
+        (when (pos? port) port)
 
         user-info
         (.getUserInfo uri)
@@ -64,34 +98,23 @@
           (str/starts-with? path "/")
           (subs 1))
 
-        query
-        (.getQuery uri)
-
-        query-args
-        (when query
-          (as-> query *
-            (str/split * #"&")
-            (mapcat #(str/split % #"=" 2) *)))
-
-        _
-        (when (-> query-args count even? not)
-          (error! "malformed query params: %s" query))
-
         query-params
-        (apply hash-map query-args)
+        (some-> uri .getQuery parse-query-string)
 
         [user password]
         (when user-info
           (str/split user-info #":" 2))
 
         user
-        (get query-params "user" (not-empty user))
+        (or (get query-params "user")
+            (not-empty user))
 
         password
-        (get query-params "password" (not-empty password))
+        (or (get query-params "password")
+            (not-empty password))
 
         {:strs [read-only
-                options
+                pg-params
 
                 ;; socket options
                 so-keep-alive
@@ -110,8 +133,12 @@
 
                 ;; ssl
                 ssl
-
+                ssl-context
                 ;; TODO: ssl certs for ssl context?
+
+                fn-notification
+                fn-protocol-version
+                fn-notice
 
                 ;; TODO: unix:// or file:// scheme for unix socket?
                 ;; unix-socket
@@ -121,6 +148,9 @@
                 cancel-timeout-ms
                 protocol-version
 
+                ;; json
+                object-mapper
+
                 ;; pool
                 pool-min-size
                 pool-max-size
@@ -128,47 +158,123 @@
                 pool-borrow-conn-timeout-ms
 
                 ;; types
-                ;with-pgvector?
+                with-pgvector
 
-                ;; JDBC URI compatibility
+                ;; JDBC camelCase options
                 readOnly
+                connectTimeout
                 ApplicationName
                 cancelSignalTimeout
                 binaryTransfer
                 tcpKeepAlive
                 tcpNoDelay
                 protocolVersion]}
-        query-params
+        query-params]
 
-        config
-        {;; common fields
-         :host host
-         :port port
-         :user user
-         :password password
-         :database database
-         :use-ssl? (some? ssl)
-         :binary-decode? (coalesce-fn parse-query-bool binary-decode binaryTransfer)
-         :binary-encode? (coalesce-fn parse-query-bool binary-encode binaryTransfer)
-         :cancel-timeout-ms (coalesce-fn parse-query-long cancel-timeout-ms cancelSignalTimeout)
-         :in-stream-buf-size (parse-query-long in-stream-buf-size)
-         :out-stream-buf-size (parse-query-long out-stream-buf-size)
-         :pool-borrow-conn-timeout-ms (parse-query-long pool-borrow-conn-timeout-ms)
-         :pool-expire-threshold-ms (parse-query-long pool-expire-threshold-ms)
-         :pool-max-size (parse-query-long pool-max-size)
-         :pool-min-size (parse-query-long pool-min-size)
-         :protocol-version (coalesce-fn parse-query-long protocol-version protocolVersion)
-         :read-only? (coalesce-fn parse-query-bool read-only readOnly)
-         :so-keep-alive? (coalesce-fn parse-query-bool so-keep-alive tcpKeepAlive)
-         :so-recv-buf-size (parse-query-long so-recv-buf-size)
-         :so-send-buf-size (parse-query-long so-send-buf-size)
-         :so-tcp-no-delay? (coalesce-fn parse-query-bool so-tcp-no-delay tcpNoDelay)
-         :so-timeout (parse-query-long so-timeout)
-         :pg-params (cond-> {}
-                      options
-                      (assoc "options"  options)
+    {;; general
+     :user user
+     :database database
+     :host host
+     :port port
+     :password password
 
-                      ApplicationName
-                      (assoc "application_name" ApplicationName))}]
+     ;; Next.JDBC
+     :dbname database
 
-    (into {} non-nil-entries-xf config)))
+     ;; enc/dec format
+     :binary-encode?
+     (some-> (or binaryTransfer binary-encode) parse-bool)
+
+     :binary-decode?
+     (some-> (or binary-decode binaryTransfer) parse-bool)
+
+     ;; copy in/out
+     :in-stream-buf-size
+     (some-> in-stream-buf-size parse-long)
+
+     :out-stream-buf-size
+     (some-> out-stream-buf-size parse-long)
+
+     ;; handlers
+
+     :fn-notification
+     (some-> fn-notification parse-ref)
+
+     :fn-protocol-version
+     (some-> fn-protocol-version parse-ref)
+
+     :fn-notice
+     (some-> fn-notice parse-ref)
+
+     ;; ssl
+     :use-ssl?
+     (some-> ssl parse-bool)
+
+     :ssl-context
+     (some-> ssl-context parse-ref)
+
+     ;; TODO unix domain socket
+     ;; :unix-socket?
+     ;; :unix-socket-path
+
+     ;; socket
+     :so-keep-alive?
+     (some-> (or so-keep-alive tcpKeepAlive) parse-bool)
+
+     :so-tcp-no-delay?
+     (some-> (or so-tcp-no-delay tcpNoDelay) parse-bool)
+
+     :so-timeout
+     (some-> (or so-timeout connectTimeout) parse-long)
+
+     :so-recv-buf-size
+     (some-> so-recv-buf-size parse-long)
+
+     :so-send-buf-size
+     (some-> so-send-buf-size parse-long)
+
+     ;; TODO logging
+     ;; :log-level
+
+     ;; json
+     :object-mapper
+     (some-> object-mapper parse-ref)
+
+     ;; read only
+
+     :read-only?
+     (some-> (or read-only readOnly) parse-bool)
+
+     ;; misc
+
+     :cancel-timeout-ms
+     (some-> (or cancel-timeout-ms cancelSignalTimeout) parse-long)
+
+     :protocol-version
+     (some-> (or protocol-version protocolVersion) parse-long)
+
+     ;; pool
+
+     :pool-borrow-conn-timeout-ms
+     (some-> pool-borrow-conn-timeout-ms parse-long)
+
+     :pool-expire-threshold-ms
+     (some-> pool-expire-threshold-ms parse-long)
+
+     :pool-max-size
+     (some-> pool-max-size parse-long)
+
+     :pool-min-size
+     (some-> pool-min-size parse-long)
+
+     ;; TODO types
+     ;; :type-map
+     ;; :enums
+
+     :with-pgvector?
+     (some-> with-pgvector parse-bool)
+
+     :pg-params
+     (cond-> pg-params
+       ApplicationName
+       (assoc "application_name" ApplicationName))}))

--- a/pg-core/src/clj/pg/core.clj
+++ b/pg-core/src/clj/pg/core.clj
@@ -230,7 +230,7 @@
       (.reducer (fold/into (clojure.core/first into)
                            (second into)))
 
-      ;;
+      ;; end reducers
 
       (some? binary-encode?)
       (.binaryEncode binary-encode?)
@@ -279,12 +279,29 @@
 
 (defn ->config
   "
-  Turn a Clojure map into an instance of Config via Config.Builder
+  Turn a Clojure map into an instance of `Config` via `Config.Builder`.
+  First, try to parse the `connection-uri` URI string, if passed.
+  Then merge it with other parameters. Finally, build a `Config`
+  instance.
   "
   ^Config [params]
-  (let [uri-params (some-> params :connection-uri connection-uri/parse)
-        pg-params (not-empty (merge (:pg-params uri-params) (:pg-params params)))
-        params (merge uri-params params)
+
+  (let [{:keys [connection-uri
+                pg-params]}
+        params
+
+        uri-params
+        (some-> connection-uri connection-uri/parse)
+
+        {uri-pg-params :pg-params}
+        uri-params
+
+        pg-params
+        (merge uri-pg-params pg-params)
+
+        params
+        (merge uri-params params)
+
         {:keys [;; general
                 user
                 database
@@ -352,11 +369,9 @@
         params
 
         DB
-        (or database dbname)
+        (or database dbname)]
 
-        ^Config$Builder builder (new Config$Builder user DB)]
-
-    (cond-> builder
+    (cond-> (new Config$Builder user DB)
 
       password
       (.password password)
@@ -370,7 +385,7 @@
       protocol-version
       (.protocolVersion protocol-version)
 
-      pg-params
+      (seq pg-params)
       (.pgParams pg-params)
 
       (some? binary-encode?)
@@ -459,7 +474,6 @@
 
       :finally
       (.build))))
-
 
 (defn connect
 

--- a/pg-core/test/pg/client_test.clj
+++ b/pg-core/test/pg/client_test.clj
@@ -995,7 +995,7 @@ from
 
   (let [config
         (assoc *CONFIG-TXT* :pg-params {"application_name" "Clojure"
-                                    "DateStyle" "ISO, MDY"})]
+                                        "DateStyle" "ISO, MDY"})]
 
     (pg/with-connection [conn config]
       (let [param
@@ -4276,6 +4276,13 @@ copy (select s.x as X from generate_series(1, 3) as s(x)) TO STDOUT WITH (FORMAT
         (is (-> e
                 ex-message
                 (str/ends-with? ", sql: COPY +++ from ABC")))))))
+
+
+(deftest test-client-connection-uri
+  (let [uri (format "postgresql://test:test@localhost:%s/test?ssl=false" *PORT*)]
+    (pg/with-conn [conn {:connection-uri uri}]
+      (let [res (pg/query conn "select 1 as num")]
+        (is (= [{:num 1}] res))))))
 
 
 #_

--- a/pg-core/test/pg/config_test.clj
+++ b/pg-core/test/pg/config_test.clj
@@ -2,29 +2,48 @@
   (:import org.pg.Config)
   (:require
    [clojure.test :refer [deftest is testing]]
+   [pg.connection-uri :as uri]
    [pg.core :as pg]))
 
-(defn config->map
-  [^Config config]
-  {:database (.database config)
-   :user (.user config)
-   :password (.password config)
-   :port (.port config)
-   :host (.host config)})
+(set! *warn-on-reflection* true)
 
-(defn record->map [r]
-  (into {} (for [^java.lang.reflect.RecordComponent c (seq (.getRecordComponents (class r)))]
-             [(keyword (.getName c))
-              (.invoke (.getAccessor c) r nil)])))
+(def FIELDS_MIN
+  [:database
+   :user
+   :password
+   :port
+   :host])
+
+(defn record->map
+  "
+  Turn a Java record into a Clojure map via reflection.
+  Fields, if passed, act like `select-keys` to truncate
+  the final map.
+  "
+  ([r]
+   (into {} (for [^java.lang.reflect.RecordComponent c
+                  (seq (.getRecordComponents (class r)))]
+              [(keyword (.getName c))
+               (.invoke (.getAccessor c) r nil)])))
+  ([r fields]
+   (-> r
+       record->map
+       (select-keys fields))))
+
+(defn options->map
+  ([options]
+   (options->map options FIELDS_MIN))
+
+  ([options fields]
+   (-> options pg/->config (record->map fields))))
 
 (deftest test-config-minimal
-  (let [^Config config (pg/->config {:user "testuser" :database "testdb"})]
-    (is (= {:database "testdb"
-            :user "testuser"
-            :host "127.0.0.1"
-            :port 5432
-            :password ""}
-           (config->map config)))))
+  (is (= {:user "testuser",
+          :database "testdb",
+          :host "127.0.0.1",
+          :port 5432,
+          :password ""}
+         (options->map {:user "testuser" :database "testdb"}))))
 
 (deftest test-config-connection-uri
   (is (= {:database "test"
@@ -32,7 +51,9 @@
           :host "localhost"
           :port 5432
           :password "secret"}
-         (config->map (pg/->config {:connection-uri "jdbc:postgresql://fred:secret@localhost/test?ssl=true"}))))
+         (-> {:connection-uri "jdbc:postgresql://fred:secret@localhost/test?ssl=true"}
+             (options->map))))
+
   (testing "parameters"
     (is (= {:SOKeepAlive false
             :SOReceiveBufSize 999
@@ -54,47 +75,44 @@
             :user "fred"
             :pgParams {"application_name" "pg2"
                        "client_encoding" "UTF8"
-                       "default_transaction_read_only" "on"
-                       "options" "-c statement_timeout=99"}}
-           (select-keys
-            (record->map
-             (pg/->config {:connection-uri (str "jdbc:postgresql://unused@localhost/"
-                                                "test?user=fred"
-                                                "&binary-encode=true"
-                                                "&read-only=true"
-                                                "&so-keep-alive=no"
-                                                "&so-tcp-no-delay=off"
-                                                "&cancel-timeout-ms=4321"
-                                                "&protocol-version=42"
-                                                "&pool-min-size=3"
-                                                "&pool-max-size=4"
-                                                "&pool-expire-threshold-ms=3322"
-                                                "&pool-borrow-conn-timeout-ms=449"
-                                                "&ssl=1"
-                                                "&options=-c%20statement_timeout=99"
-                                                "&so-recv-buf-size=999"
-                                                "&so-send-buf-size=888"
-                                                "&so-timeout=212"
-                                                "&in-stream-buf-size=77"
-                                                "&out-stream-buf-size=45")}))
-            [:user :password
-             :SOKeepAlive
-             :SOReceiveBufSize
-             :SOSendBufSize
-             :SOTCPnoDelay
-             :binaryDecode
-             :binaryEncode
-             :cancelTimeoutMs
-             :inStreamBufSize
-             :outStreamBufSize
-             :poolBorrowConnTimeoutMs
-             :poolExpireThresholdMs
-             :poolMaxSize
-             :poolMinSize
-             :protocolVersion
-             :readOnly
-             :useSSL
-             :pgParams])))))
+                       "default_transaction_read_only" "on"}}
+
+           (-> {:connection-uri (str "jdbc:postgresql://unused@localhost/"
+                                     "test?user=fred"
+                                     "&binary-encode=true"
+                                     "&read-only=true"
+                                     "&so-keep-alive=no"
+                                     "&so-tcp-no-delay=off"
+                                     "&cancel-timeout-ms=4321"
+                                     "&protocol-version=42"
+                                     "&pool-min-size=3"
+                                     "&pool-max-size=4"
+                                     "&pool-expire-threshold-ms=3322"
+                                     "&pool-borrow-conn-timeout-ms=449"
+                                     "&ssl=1"
+                                     "&so-recv-buf-size=999"
+                                     "&so-send-buf-size=888"
+                                     "&so-timeout=212"
+                                     "&in-stream-buf-size=77"
+                                     "&out-stream-buf-size=45")}
+               (options->map [:user :password
+                              :SOKeepAlive
+                              :SOReceiveBufSize
+                              :SOSendBufSize
+                              :SOTCPnoDelay
+                              :binaryDecode
+                              :binaryEncode
+                              :cancelTimeoutMs
+                              :inStreamBufSize
+                              :outStreamBufSize
+                              :poolBorrowConnTimeoutMs
+                              :poolExpireThresholdMs
+                              :poolMaxSize
+                              :poolMinSize
+                              :protocolVersion
+                              :readOnly
+                              :useSSL
+                              :pgParams]))))))
 
 (deftest test-config-connection-uri-precedence
   (testing "prefer direct map options, then PG2 named params, then JDBC params"
@@ -102,19 +120,18 @@
             :password ""
             :protocolVersion 1
             :user "user"}
-           (select-keys
-            (record->map
-             (pg/->config {:protocol-version 1
-                           :user "user"
-                           :connection-uri (str "jdbc:postgresql://unused@localhost/"
-                                                "test?user=notthisuser"
-                                                "&protocol-version=2"
-                                                "&protocolVersion=3"
-                                                "&cancel-timeout-ms=777"
-                                                "&cancelSignalTimeout=888")}))
-            [:user :password :cancelTimeoutMs :protocolVersion])))))
+           (-> {:protocol-version 1
+                :user "user"
+                :connection-uri (str "jdbc:postgresql://unused@localhost/"
+                                     "test?user=notthisuser"
+                                     "&protocol-version=2"
+                                     "&protocolVersion=3"
+                                     "&cancel-timeout-ms=777"
+                                     "&cancelSignalTimeout=888")}
+               (options->map [:user :password :cancelTimeoutMs :protocolVersion]))))))
 
 (deftest test-config-connection-uri-jdbc-compat
+
   (testing "multiple ways to specify user/password"
     (let [expected {:database "test"
                     :user "fred"
@@ -122,11 +139,12 @@
                     :port 5432
                     :password "secret"}]
       (is (= expected
-             (config->map (pg/->config {:connection-uri "jdbc:postgresql://fred@localhost/test?password=secret&ssl=true"}))))
+             (options->map {:connection-uri "jdbc:postgresql://fred@localhost/test?password=secret&ssl=true"})))
       (is (= expected
-             (config->map (pg/->config {:connection-uri "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true"}))))
+             (options->map {:connection-uri "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true"})))
       (is (= expected
-             (config->map (pg/->config {:connection-uri "jdbc:postgresql://fred:secret@localhost/test?ssl=true"}))))))
+             (options->map {:connection-uri "jdbc:postgresql://fred:secret@localhost/test?ssl=true"})))))
+
   (testing "scheme differences"
     (let [expected {:database "test"
                     :user "fred"
@@ -134,11 +152,12 @@
                     :port 5432
                     :password ""}]
       (is (= expected
-             (config->map (pg/->config {:connection-uri "postgresql://localhost/test?user=fred"}))))
+             (options->map {:connection-uri "postgresql://localhost/test?user=fred"})))
       (is (= expected
-             (config->map (pg/->config {:connection-uri "jdbc:postgresql://localhost/test?user=fred"}))))
+             (options->map {:connection-uri "jdbc:postgresql://localhost/test?user=fred"})))
       (is (= expected
-             (config->map (pg/->config {:connection-uri "postgres://localhost/test?user=fred"}))))))
+             (options->map {:connection-uri "postgres://localhost/test?user=fred"})))))
+
   (testing "no password"
     (let [expected {:database "test"
                     :user "fred"
@@ -146,9 +165,10 @@
                     :port 5432
                     :password ""}]
       (is (= expected
-             (config->map (pg/->config {:connection-uri "jdbc:postgresql://fred@localhost/test"}))))
+             (options->map {:connection-uri "jdbc:postgresql://fred@localhost/test"})))
       (is (= expected
-             (config->map (pg/->config {:connection-uri "jdbc:postgresql://localhost/test?user=fred"}))))))
+             (options->map {:connection-uri "jdbc:postgresql://localhost/test?user=fred"})))))
+
   (testing "other parameters"
     (is (= {:SOKeepAlive false
             :SOTCPnoDelay false,
@@ -163,8 +183,101 @@
             :pgParams {"application_name" "foo"
                        "client_encoding" "UTF8"
                        "default_transaction_read_only" "on"}}
-           (select-keys
-            (record->map
-             (pg/->config {:connection-uri "jdbc:postgresql://localhost/test?user=fred&binaryTransfer=true&readOnly=true&tcpKeepAlive=false&tcpNoDelay=false&cancelSignalTimeout=4321&ApplicationName=foo&protocolVersion=42&ssl=on"}))
-            [:user :password :SOKeepAlive :SOTCPnoDelay :binaryEncode :binaryDecode
-             :cancelTimeoutMs :protocolVersion :readOnly :useSSL :pgParams])))))
+           (-> {:connection-uri (str "jdbc:postgresql://localhost/test"
+                                     "?user=fred"
+                                     "&binaryTransfer=true"
+                                     "&readOnly=true"
+                                     "&tcpKeepAlive=false"
+                                     "&tcpNoDelay=false"
+                                     "&cancelSignalTimeout=4321"
+                                     "&ApplicationName=foo"
+                                     "&protocolVersion=42"
+                                     "&ssl=on")}
+               (options->map [:user :password
+                              :SOKeepAlive :SOTCPnoDelay
+                              :binaryEncode
+                              :binaryDecode
+                              :cancelTimeoutMs :protocolVersion
+                              :readOnly :useSSL :pgParams]))))))
+
+(deftest test-parse-ref-fields
+  (is (= {:user "fred",
+          :fnNotification clojure.core/println}
+         (-> {:connection-uri "postgresql://fred:secret@localhost/test?fn-notification=clojure.core/println"}
+             (options->map [:user :fnNotification]))))
+
+  (is (= {:user "fred",
+          :fnNotification clojure.core/+}
+         (-> {:connection-uri "postgresql://fred:secret@localhost/test?fn-notification=clojure.core/println"
+              :fn-notification clojure.core/+}
+             (options->map [:user :fnNotification])))))
+
+(deftest test-parse-nested-params
+  (is (= {:user "fred",
+          :pgParams {"application_name" "pg2"
+                     "client_encoding" "UTF8"
+                     "opt_one" "aa,bb,cc"
+                     "opt_two" "100500.00"}}
+         (-> {:connection-uri "postgresql://fred:secret@localhost/test?pg-params.opt_one=aa,bb,cc&pg-params.opt_two=100500.00"}
+             (options->map [:user :pgParams])))))
+
+(deftest test-weird-cases
+
+  (try
+    (-> {:connection-uri "postgresql://fred:secret@localhost/test?fn-notification=clojure.core/ASDdfg34324"}
+        (options->map))
+    (is false)
+    (catch Exception e
+      (is (= "cannot resolve a reference: clojure.core/ASDdfg34324, reason: reference not found: clojure.core/ASDdfg34324"
+             (ex-message e)))))
+
+  (try
+    (-> {:connection-uri "postgresql://fred:secret@localhost/test?fn-notification=ASDdfg34324"}
+        (options->map))
+    (is false)
+    (catch Exception e
+      (is (= "cannot resolve a reference: ASDdfg34324, reason: Not a qualified symbol: ASDdfg34324"
+             (ex-message e)))))
+
+  (try
+    (-> {:connection-uri "postgresql://fred:secret@localhost/test?cancel-timeout-ms=asdfad"}
+        (options->map))
+    (is false)
+    (catch Exception e
+      (is (= "cannot parse long value: asdfad, reason: For input string: \"asdfad\""
+             (ex-message e)))))
+
+  (try
+    (-> {:connection-uri "postgresql://fred:secret@localhost/test?binary-encode=dunno"}
+        (options->map))
+    (is false)
+    (catch Exception e
+      (is (= "cannot parse boolean value: dunno"
+             (ex-message e))))))
+
+
+(deftest test-parse-query-string
+
+  (is (= nil
+         (uri/parse-query-string "")))
+
+  (is (= nil
+         (uri/parse-query-string nil)))
+
+  (is (= nil
+         (uri/parse-query-string "a")))
+
+  (is (= {"a" "1"}
+         (uri/parse-query-string "a=1")))
+
+  (is (= nil
+         (uri/parse-query-string "a=")))
+
+  (is (= {"a" "2"}
+         (uri/parse-query-string "a=1&a=2")))
+
+  (is (= {"a" "1" "b" "2"}
+         (uri/parse-query-string "a=1&b=2")))
+
+  (is (= {"a" {"b" "1", "c" "2"}}
+         (uri/parse-query-string "a.b=1&a.c=2"))))

--- a/pg-core/test/pg/config_test.clj
+++ b/pg-core/test/pg/config_test.clj
@@ -1,0 +1,170 @@
+(ns pg.config-test
+  (:import org.pg.Config)
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [pg.core :as pg]))
+
+(defn config->map
+  [^Config config]
+  {:database (.database config)
+   :user (.user config)
+   :password (.password config)
+   :port (.port config)
+   :host (.host config)})
+
+(defn record->map [r]
+  (into {} (for [^java.lang.reflect.RecordComponent c (seq (.getRecordComponents (class r)))]
+             [(keyword (.getName c))
+              (.invoke (.getAccessor c) r nil)])))
+
+(deftest test-config-minimal
+  (let [^Config config (pg/->config {:user "testuser" :database "testdb"})]
+    (is (= {:database "testdb"
+            :user "testuser"
+            :host "127.0.0.1"
+            :port 5432
+            :password ""}
+           (config->map config)))))
+
+(deftest test-config-connection-uri
+  (is (= {:database "test"
+          :user "fred"
+          :host "localhost"
+          :port 5432
+          :password "secret"}
+         (config->map (pg/->config {:connection-uri "jdbc:postgresql://fred:secret@localhost/test?ssl=true"}))))
+  (testing "parameters"
+    (is (= {:SOKeepAlive false
+            :SOReceiveBufSize 999
+            :SOSendBufSize 888
+            :SOTCPnoDelay false,
+            :binaryDecode false
+            :binaryEncode true
+            :cancelTimeoutMs 4321
+            :inStreamBufSize 77
+            :outStreamBufSize 45
+            :password ""
+            :poolMinSize 3
+            :poolMaxSize 4
+            :poolBorrowConnTimeoutMs 449
+            :poolExpireThresholdMs 3322
+            :protocolVersion 42
+            :readOnly true
+            :useSSL true
+            :user "fred"
+            :pgParams {"application_name" "pg2"
+                       "client_encoding" "UTF8"
+                       "default_transaction_read_only" "on"
+                       "options" "-c statement_timeout=99"}}
+           (select-keys
+            (record->map
+             (pg/->config {:connection-uri (str "jdbc:postgresql://unused@localhost/"
+                                                "test?user=fred"
+                                                "&binary-encode=true"
+                                                "&read-only=true"
+                                                "&so-keep-alive=no"
+                                                "&so-tcp-no-delay=off"
+                                                "&cancel-timeout-ms=4321"
+                                                "&protocol-version=42"
+                                                "&pool-min-size=3"
+                                                "&pool-max-size=4"
+                                                "&pool-expire-threshold-ms=3322"
+                                                "&pool-borrow-conn-timeout-ms=449"
+                                                "&ssl=1"
+                                                "&options=-c%20statement_timeout=99"
+                                                "&so-recv-buf-size=999"
+                                                "&so-send-buf-size=888"
+                                                "&so-timeout=212"
+                                                "&in-stream-buf-size=77"
+                                                "&out-stream-buf-size=45")}))
+            [:user :password
+             :SOKeepAlive
+             :SOReceiveBufSize
+             :SOSendBufSize
+             :SOTCPnoDelay
+             :binaryDecode
+             :binaryEncode
+             :cancelTimeoutMs
+             :inStreamBufSize
+             :outStreamBufSize
+             :poolBorrowConnTimeoutMs
+             :poolExpireThresholdMs
+             :poolMaxSize
+             :poolMinSize
+             :protocolVersion
+             :readOnly
+             :useSSL
+             :pgParams])))))
+
+(deftest test-config-connection-uri-precedence
+  (testing "prefer direct map options, then PG2 named params, then JDBC params"
+    (is (= {:cancelTimeoutMs 777
+            :password ""
+            :protocolVersion 1
+            :user "user"}
+           (select-keys
+            (record->map
+             (pg/->config {:protocol-version 1
+                           :user "user"
+                           :connection-uri (str "jdbc:postgresql://unused@localhost/"
+                                                "test?user=notthisuser"
+                                                "&protocol-version=2"
+                                                "&protocolVersion=3"
+                                                "&cancel-timeout-ms=777"
+                                                "&cancelSignalTimeout=888")}))
+            [:user :password :cancelTimeoutMs :protocolVersion])))))
+
+(deftest test-config-connection-uri-jdbc-compat
+  (testing "multiple ways to specify user/password"
+    (let [expected {:database "test"
+                    :user "fred"
+                    :host "localhost"
+                    :port 5432
+                    :password "secret"}]
+      (is (= expected
+             (config->map (pg/->config {:connection-uri "jdbc:postgresql://fred@localhost/test?password=secret&ssl=true"}))))
+      (is (= expected
+             (config->map (pg/->config {:connection-uri "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true"}))))
+      (is (= expected
+             (config->map (pg/->config {:connection-uri "jdbc:postgresql://fred:secret@localhost/test?ssl=true"}))))))
+  (testing "scheme differences"
+    (let [expected {:database "test"
+                    :user "fred"
+                    :host "localhost"
+                    :port 5432
+                    :password ""}]
+      (is (= expected
+             (config->map (pg/->config {:connection-uri "postgresql://localhost/test?user=fred"}))))
+      (is (= expected
+             (config->map (pg/->config {:connection-uri "jdbc:postgresql://localhost/test?user=fred"}))))
+      (is (= expected
+             (config->map (pg/->config {:connection-uri "postgres://localhost/test?user=fred"}))))))
+  (testing "no password"
+    (let [expected {:database "test"
+                    :user "fred"
+                    :host "localhost"
+                    :port 5432
+                    :password ""}]
+      (is (= expected
+             (config->map (pg/->config {:connection-uri "jdbc:postgresql://fred@localhost/test"}))))
+      (is (= expected
+             (config->map (pg/->config {:connection-uri "jdbc:postgresql://localhost/test?user=fred"}))))))
+  (testing "other parameters"
+    (is (= {:SOKeepAlive false
+            :SOTCPnoDelay false,
+            :binaryDecode true
+            :binaryEncode true
+            :cancelTimeoutMs 4321
+            :password ""
+            :protocolVersion 42
+            :readOnly true
+            :useSSL true
+            :user "fred"
+            :pgParams {"application_name" "foo"
+                       "client_encoding" "UTF8"
+                       "default_transaction_read_only" "on"}}
+           (select-keys
+            (record->map
+             (pg/->config {:connection-uri "jdbc:postgresql://localhost/test?user=fred&binaryTransfer=true&readOnly=true&tcpKeepAlive=false&tcpNoDelay=false&cancelSignalTimeout=4321&ApplicationName=foo&protocolVersion=42&ssl=on"}))
+            [:user :password :SOKeepAlive :SOTCPnoDelay :binaryEncode :binaryDecode
+             :cancelTimeoutMs :protocolVersion :readOnly :useSSL :pgParams])))))

--- a/todo.md
+++ b/todo.md
@@ -31,6 +31,16 @@ https://www.postgresql.org/docs/current/libpq-pgpass.html
 - ssl services local tests
 - CodecParams (setParam) make it mutable
 
+- connection URI:
+  - docs
+  - ssl-cert-files
+  - unix socket
+  - logging
+  - enums
+  - type-map
+  - connect: accept a string?
+
+config & uri: rename pg-params to params?
 
 - postgis support
 - json wrapper not needed
@@ -84,3 +94,6 @@ migrations
   - get-by-ids-temp
   - copy in/out
   - truncate
+
+- save notifications into a list?
+- get-notifications function?

--- a/todo.md
+++ b/todo.md
@@ -65,7 +65,6 @@ https://www.postgresql.org/docs/current/libpq-pgpass.html
   - enums
 - keywords with namespaces (+ jdbc)
 - test parallel connection access
-- parse JDBC url
 - bulk statement execute
 - pg.jdbc batch
 - refactor locks? on Clojure level


### PR DESCRIPTION
Allow connection URIs of the following form:

    [jdbc:]postgresql://user:password@host:port/dbname?opt=val

(where the jdbc: prefix is optional)

The supported options in the query string are currently:

- user
- password
- binaryTransfer (true/false)
- readOnly (true/false)
- ssl (presence enables)
- tcpKeepAlive (true/false)
- tcpNoDelay (true/false)
- socketTimeout (int)
- cancelSignalTimeout (int)
- ApplicationName
- protocolVersion (int)

These case-sensitive options should match those specifiable when using the "official" pgjdbc driver.