### PR TITLE
Use AsynchronousSocketChannel to make connection

### DIFF
--- a/pg-core/src/java/org/pg/util/SocketTool.java
+++ b/pg-core/src/java/org/pg/util/SocketTool.java
@@ -5,14 +5,20 @@ import org.pg.error.PGError;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.util.concurrent.Future;
+import java.util.concurrent.ExecutionException;
+import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.SocketChannel;
 
 public class SocketTool {
 
-    public static SocketChannel open (final SocketAddress address) {
+    public static AsynchronousSocketChannel open (final SocketAddress address) {
         try {
-            return SocketChannel.open(address);
-        } catch (IOException e) {
+            final AsynchronousSocketChannel ch = AsynchronousSocketChannel.open();
+            Future result = ch.connect(address);
+            result.get();
+            return ch;
+        } catch (IOException | InterruptedException | ExecutionException e) {
             throw new PGError(e, "cannot open socket, address: %s", address);
         }
     }

--- a/pg-core/src/java/org/pg/util/SocketTool.java
+++ b/pg-core/src/java/org/pg/util/SocketTool.java
@@ -12,13 +12,21 @@ import java.nio.channels.SocketChannel;
 
 public class SocketTool {
 
-    public static AsynchronousSocketChannel open (final SocketAddress address) {
+    public static AsynchronousSocketChannel openAsync (final SocketAddress address, long timeout) {
         try {
             final AsynchronousSocketChannel ch = AsynchronousSocketChannel.open();
             Future result = ch.connect(address);
-            result.get();
+            result.get(timeout);
             return ch;
         } catch (IOException | InterruptedException | ExecutionException e) {
+            throw new PGError(e, "cannot open socket, address: %s", address);
+        }
+    }
+
+    public static SocketChannel open (final SocketAddress address) {
+        try {
+            return SocketChannel.open(address);
+        } catch (IOException e) {
             throw new PGError(e, "cannot open socket, address: %s", address);
         }
     }

--- a/pg-core/src/java/org/pg/util/SocketTool.java
+++ b/pg-core/src/java/org/pg/util/SocketTool.java
@@ -7,6 +7,8 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.util.concurrent.Future;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.TimeUnit;
 import java.nio.channels.AsynchronousSocketChannel;
 import java.nio.channels.SocketChannel;
 
@@ -16,8 +18,10 @@ public class SocketTool {
         try {
             final AsynchronousSocketChannel ch = AsynchronousSocketChannel.open();
             Future result = ch.connect(address);
-            result.get(timeout);
+            result.get(timeout, TimeUnit.MILLISECONDS);
             return ch;
+        } catch (TimeoutException e) {
+            throw new PGError(e, "timed out while connecting to address: %s", address);
         } catch (IOException | InterruptedException | ExecutionException e) {
             throw new PGError(e, "cannot open socket, address: %s", address);
         }


### PR DESCRIPTION
The streams created from `java.nio.AsynchronousSocketChannel` are non-blocking under the hood, but *act* blocking from a consumer's standpoint. This means that calling `.interrupt` on a Thread doing a read from this stream will actually get interrupted rather than continuing to block until finished. I'm not an expert in this area, but this minimal change seems to work quite well.

I ran the pg-bench suite and it seems like this may actually improve performance slightly, if only a few percent.

This also adds a (un-exposed for now) method on connection to put it in "listen for notifications" mode. This did not work before with the standard java.io sockets, as those use truly blocking reads.