### PR TITLE
Common API (Data Source Abstraction)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,6 @@ test:
 snapshot:
 	lein sub with-profile uberjar install
 	lein sub with-profile uberjar deploy
+
+repl: install
+	cd pg-core && make repl

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ tests][tests].
 - [Benchmarks](/docs/benchmarks.md)
 - [Authentication](/docs/authentication.md)
 - [Connecting to the Server](/docs/connecting.md)
+- [Data Source Abstraction](/docs/data-source.md)
 - [URI Connection String](/docs/connection-uri.md)
 - [Query and Execute](/docs/query-execute.md)
 - [Prepared Statements](/docs/prepared-statement.md)

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -24,12 +24,21 @@ might be skipped (the password is an empty string by default). Only the `:user`
 and `:database` fields are required when connecting. See the list of possible
 fields and their values in a table below.
 
-Another way to specify connection parameters is to use a URI string:
+Another way to specify connection parameters is to use a URI string. Below, it
+acts as a part of a config map:
 
 ~~~clojure
 (def URI "postgresql://test:query123@127.0.0.1:5432/test?ssl=false")
 
 (pg/with-conn [conn {:connection-uri URI}]
+  (let [res (pg/query conn "select 1 as num")]
+    ...))
+~~~
+
+Or just pass a URI without wrapping it into a map:
+
+~~~clojure
+(pg/with-conn [conn URI]
   (let [res (pg/query conn "select 1 as num")]
     ...))
 ~~~

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -145,12 +145,12 @@ The `:read-only?` connection parameter does two things under the hood:
 1. It appends the `default_transaction_read_only` parameter to the startup
    message set to `on`. Thus, any transaction gets started on `READ ONLY` mode.
 
-2. It prevents the `:read-only?` flag from overriding in the `with-tx`
+2. It prevents the `:read-only?` flag from overriding in the `with-transaction`
    macro. Say, even if the macro is called like this:
 
 ~~~clojure
-(pg/with-tx [conn {:read-only? false}] ;; try to mute the global :read-only? flag
-  (pg/query conn "delete from students"))
+(pg/with-transaction [tx conn {:read-only? false}] ;; try to mute the global :read-only? flag
+  (pg/query tx "delete from students"))
 ~~~
 
 The transaction will be in `READ ONLY` mode anyway.

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -35,7 +35,7 @@ acts as a part of a config map:
     ...))
 ~~~
 
-Or just pass a URI without wrapping it into a map:
+Or just pass a URI as is:
 
 ~~~clojure
 (pg/with-conn [conn URI]

--- a/docs/connecting.md
+++ b/docs/connecting.md
@@ -1,6 +1,6 @@
 # Connecting to the Server
 
-To connect the server, define a config map and pass it into the `connect`
+To connect to a database, define a config map and pass it into the `connect`
 function:
 
 ~~~clojure
@@ -22,7 +22,19 @@ The `conn` is an instance of the `org.pg.Connection` class.
 The `:host`, `:port`, and `:password` config fields have default values and
 might be skipped (the password is an empty string by default). Only the `:user`
 and `:database` fields are required when connecting. See the list of possible
-fields and their values in a separate section.
+fields and their values in a table below.
+
+Another way to specify connection parameters is to use a URI string:
+
+~~~clojure
+(def URI "postgresql://test:query123@127.0.0.1:5432/test?ssl=false")
+
+(pg/with-conn [conn {:connection-uri URI}]
+  (let [res (pg/query conn "select 1 as num")]
+    ...))
+~~~
+
+See the [URI Connection String](/docs/connection-uri.md) section for details.
 
 To close a connection, pass it into the `close` function:
 
@@ -30,12 +42,11 @@ To close a connection, pass it into the `close` function:
 (pg/close conn)
 ~~~
 
-You cannot open or use this connection again afterwards.
+Once closed, a connection cannot be reopened or used afterwards.
 
-To close the connection automatically, use either `with-connection` or
-`with-open` macro. The `with-connection` macro takes a binding symbol and a
-config map; the connection gets bound to the binding symbold while the body is
-executed:
+To close a connection automatically, use either `with-connection` or `with-open`
+macro. The `with-connection` macro takes a binding symbol and a config map; the
+connection gets bound to the binding symbol while executing the body:
 
 ~~~clojure
 (pg/with-connection [conn config]
@@ -56,7 +67,7 @@ The standard `with-open` macro calls the `(.close connection)` method on exit:
   (pg/query conn "select 1 as one"))
 ~~~
 
-Avoid situations when you close a connection manually. Use one of these two
+Please avoid cases when you close connections manually. Use one of these two
 macros shown above.
 
 Use `:pg-params` field to specify connection-specific Postgres parameters. These

--- a/docs/data-source.md
+++ b/docs/data-source.md
@@ -21,7 +21,7 @@ Now you can pass a map directly to `query`:
 (pg/query config "select 42")
 ~~~
 
-Under the hood, the library will open a new connection from this map, perform a
+Under the hood, the library opens a new connection from this map, perform a
 query and close the connection afterwards. Of course, opening a closing a
 connection on each query is much slower that reusing the same one, especially in
 a loop. But it gives you more freedom, and sometimes this is also fine in tests.
@@ -37,18 +37,33 @@ connection is returned to the pool, meaning it's now available for others.
 (pg/query pool "select 42")
 ~~~
 
+See the [Connection Pool](/docs/pool.md) section for more details about a
+connection pool.
+
+You can pass a URI string as well:
+
+~~~clojure
+(def URI "postgresql://test:test@127.0.0.1:5432/test?ssl=false")
+
+(pg/query URI "select 1")
+~~~
+
+See the [URI Connection String](/docs/connection-uri.md) section to know more
+about a URI connection string.
+
 # Supported Sources
 
 At the moment of writing this, the following objects may act as a source:
 
-| Class                         | On borrow logic               | On return logic           |
+| type                          | Borrowing logic               | Returning logic           |
 |-------------------------------|-------------------------------|---------------------------|
 | `org.pg.Connection`           | Return itself                 | Nothing (keep it open)    |
 | `org.pg.Pool`                 | Borrow one from a pool (lock) | Return to a pool (unlock) |
-| `clojure.lang.IPersistentMap` | Open a connection             | Close the connection      |
-| `org.pg.Config`               | Open a connection             | Close the connection      |
+| `clojure.lang.IPersistentMap` | Connect using a Clojure map   | Close the connection      |
+| `java.lang.String`            | Connect using a URI           | Close the connection      |
+| `org.pg.Config`               | Connect using a Config object | Close the connection      |
 
-# Naming
+# Naming Rules
 
 Some `pg.core` functions accept any data source, but some are bound to the
 `Connection` object. For example, `query`, `execute`, `copy`, etc accept a
@@ -56,7 +71,7 @@ source, but `close-statement` needs a connection because prepared statements are
 defined per connection. There is a naming rule for that:
 
 - if the first argument is called `src`, the function accepts a data source (a
-  connection, a pool, a clojure map);
+  connection, a pool, a Clojure map, a URI string);
 - if the first argument is called `conn`, it accepts a connection only. Most
   likely you need to pass a certain connection, for example the one you used for
   a prepared statement or to process notifications.

--- a/docs/data-source.md
+++ b/docs/data-source.md
@@ -1,0 +1,62 @@
+# Data Source Abstraction
+
+A recent release of PG2 has introduced something which is called a data
+source. Brifely, it's when a function accepts not a `Connection` instance only
+but rather an object implementing the `org.pg.ISource` protocol. It makes the
+function work with a connection pool or a Clojure map as well.
+
+For example, before, the `query` function accepted a connection only. You should
+have open a connection first and pass it into the `query` function:
+
+~~~clojure
+(def config {...})
+
+(pg/with-conn [conn config]
+  (pg/query conn "select 42"))
+~~~
+
+Now you can pass a map directly to `query`:
+
+~~~clojure
+(pg/query config "select 42")
+~~~
+
+Under the hood, the library will open a new connection from this map, perform a
+query and close the connection afterwards. Of course, opening a closing a
+connection on each query is much slower that reusing the same one, especially in
+a loop. But it gives you more freedom, and sometimes this is also fine in tests.
+
+What's important, you can pass a `Pool` instance into the `query` and `execute`
+functions as well. For a pool, the function borrows a connection first, making
+it unavailable consumers in other threads. Once the query is done, the
+connection is returned to the pool, meaning it's now available for others.
+
+~~~clojure
+(def pool (pg/pool {...}))
+
+(pg/query pool "select 42")
+~~~
+
+# Supported Sources
+
+At the moment of writing this, the following objects may act as a source:
+
+| Class                         | On borrow logic               | On return logic           |
+|-------------------------------|-------------------------------|---------------------------|
+| `org.pg.Connection`           | Return itself                 | Nothing (keep it open)    |
+| `org.pg.Pool`                 | Borrow one from a pool (lock) | Return to a pool (unlock) |
+| `clojure.lang.IPersistentMap` | Open a connection             | Close the connection      |
+| `org.pg.Config`               | Open a connection             | Close the connection      |
+
+# Naming
+
+Some `pg.core` functions accept any data source, but some are bound to the
+`Connection` object. For example, `query`, `execute`, `copy`, etc accept a
+source, but `close-statement` needs a connection because prepared statements are
+defined per connection. There is a naming rule for that:
+
+- if the first argument is called `src`, the function accepts a data source (a
+  connection, a pool, a clojure map);
+- if the first argument is called `conn`, it accepts a connection only. Most
+  likely you need to pass a certain connection, for example the one you used for
+  a prepared statement or to process notifications.

--- a/docs/data-source.md
+++ b/docs/data-source.md
@@ -1,12 +1,12 @@
 # Data Source Abstraction
 
-A recent release of PG2 has introduced something which is called a data
-source. Brifely, it's when a function accepts not a `Connection` instance only
-but rather an object implementing the `org.pg.ISource` protocol. It makes the
-function work with a connection pool or a Clojure map as well.
+A recent release of PG2 introduces something called a data source. Brifely, it's
+when a function accepts not a `Connection` instance only but rather an object
+implementing the `org.pg.ISource` protocol. It makes the function work with a
+connection pool, a Clojure map, or a URI string as well.
 
 For example, before, the `query` function accepted a connection only. You should
-have open a connection first and pass it into the `query` function:
+have opened a connection first and pass it into the `query` function:
 
 ~~~clojure
 (def config {...})
@@ -21,15 +21,15 @@ Now you can pass a map directly to `query`:
 (pg/query config "select 42")
 ~~~
 
-Under the hood, the library opens a new connection from this map, perform a
-query and close the connection afterwards. Of course, opening a closing a
-connection on each query is much slower that reusing the same one, especially in
-a loop. But it gives you more freedom, and sometimes this is also fine in tests.
+Under the hood, the library spawns a new connection from this map, performs a
+query and closes the connection afterwards. Of course, opening and closing a
+connection every time is much slower that reusing the same one, especially in a
+loop. But it gives you more freedom, and sometimes it is fine in tests.
 
 What's important, you can pass a `Pool` instance into the `query` and `execute`
 functions as well. For a pool, the function borrows a connection first, making
-it unavailable consumers in other threads. Once the query is done, the
-connection is returned to the pool, meaning it's now available for others.
+it unavailable for consumers in other threads. Once the query is done, the
+connection is returned to the pool, meaning it's now available for use.
 
 ~~~clojure
 (def pool (pg/pool {...}))
@@ -48,12 +48,11 @@ You can pass a URI string as well:
 (pg/query URI "select 1")
 ~~~
 
-See the [URI Connection String](/docs/connection-uri.md) section to know more
-about a URI connection string.
+See the [URI Connection String](/docs/connection-uri.md) section for details.
 
 # Supported Sources
 
-At the moment of writing this, the following objects may act as a source:
+The following objects may act as a data source:
 
 | type                          | Borrowing logic               | Returning logic           |
 |-------------------------------|-------------------------------|---------------------------|
@@ -65,13 +64,13 @@ At the moment of writing this, the following objects may act as a source:
 
 # Naming Rules
 
-Some `pg.core` functions accept any data source, but some are bound to the
-`Connection` object. For example, `query`, `execute`, `copy`, etc accept a
-source, but `close-statement` needs a connection because prepared statements are
-defined per connection. There is a naming rule for that:
+Some `pg.core` functions accept any data source, but some require a `Connection`
+object only. For example, `query`, `execute`, `copy`, etc accept a source, but
+`close-statement` needs a connection because prepared statements are defined per
+connection. There is a naming rule for that:
 
 - if the first argument is called `src`, the function accepts a data source (a
   connection, a pool, a Clojure map, a URI string);
-- if the first argument is called `conn`, it accepts a connection only. Most
-  likely you need to pass a certain connection, for example the one you used for
-  a prepared statement or to process notifications.
+- if the argument is called `conn`, it accepts a connection only. Most likely
+  you need to pass a certain connection, for example the one you used for a
+  prepared statement or to process notifications.

--- a/docs/next-jdbc-layer.md
+++ b/docs/next-jdbc-layer.md
@@ -58,7 +58,7 @@ A brief example with a connection pool and a couple of futures. Each future
 borrows a connection from a pool, and returns it afterwards.
 
 ~~~clojure
-(pool/with-pool [pool config]
+(pg/with-pool [pool config]
   (let [f1
         (future
           (jdbc/on-connection [conn1 pool]

--- a/docs/pool.md
+++ b/docs/pool.md
@@ -35,10 +35,12 @@ Here is how you use the pool:
    :password "test"
    :database "test"})
 
-(pool/with-pool [pool config]
-  (pool/with-connection [conn pool]
+(pg/with-pool [pool config]
+  (pg/with-connection [conn pool]
     (pg/execute conn "select 1 as one")))
 ~~~
+
+In the latest version of PG2, it might be even simpler: TODO
 
 The `pool/with-pool` macro creates a pool object from the `config` map and binds
 it to the `pool` symbol. Once you exit the macro, the pool gets closed.

--- a/docs/pool.md
+++ b/docs/pool.md
@@ -40,9 +40,25 @@ Here is how you use the pool:
     (pg/execute conn "select 1 as one")))
 ~~~
 
-In the latest version of PG2, it might be even simpler: TODO
+In the latest version of PG2, it might be even simpler: just pass the `Pool`
+object into the `execute` function:
 
-The `pool/with-pool` macro creates a pool object from the `config` map and binds
+~~~clojure
+(pg/with-pool [pool config]
+  (pg/execute pool "select 1 as one"))
+~~~
+
+You can also pass a URI string when spawning a pool:
+
+~~~clojure
+(def URI
+  "postgresql://test:query123@127.0.0.1:5432/test?ssl=false")
+
+(pg/with-pool [pool URI]
+  (pg/execute pool "select 1 as one"))
+~~~
+
+The `pg/with-pool` macro creates a pool object from the `config` map and binds
 it to the `pool` symbol. Once you exit the macro, the pool gets closed.
 
 The `with-pool` macro can be easily replaced with the `with-open` macro and the
@@ -50,13 +66,13 @@ The `with-pool` macro can be easily replaced with the `with-open` macro and the
 `.close` method of an opened object, which closes the pool.
 
 ~~~clojure
-(with-open [pool (pool/pool config)]
-  (pool/with-conn [conn pool]
+(with-open [pool (pg/pool config)]
+  (pg/with-conn [conn pool]
     (pg/execute conn "select 1 as one")))
 ~~~
 
-Having a pool object, use it with the `pool/with-connection` macro (there is a
-shorter version `pool/with-conn` as well). This macro borrows a connection from
+Having a pool object, use it with the `pg/with-connection` macro (there is a
+shorter version `pg/with-conn` as well). This macro borrows a connection from
 the pool and binds it to the `conn` symbol. Now you pass the connection to
 `pg/execute`, `pg/query` and so on. By exiting the `with-connection` macro, the
 connection is returned to the pool.
@@ -105,12 +121,12 @@ timeout bangs. Should there still haven't been any free connections during the
 The `stats` function returns info about free and used connections:
 
 ~~~clojure
-(pool/with-pool [pool config]
+(pg/with-pool [pool config]
 
   (pool/stats pool)
   ;; {:free 1 :used 0}
 
-  (pool/with-connection [conn pool]
+  (pg/with-connection [conn pool]
     (pool/stats pool)
     ;; {:free 0 :used 1}
   ))
@@ -130,7 +146,7 @@ when it's wrapped into a component (see [Component][component] and
 The `pool` function creates a pool:
 
 ~~~clojure
-(def POOL (pool/pool config))
+(def POOL (pg/pool config))
 ~~~
 
 The `used-count` and `free-count` functions return total numbers of busy and
@@ -147,26 +163,26 @@ free connections, respectively:
 The `pool?` predicate ensures it's a `Pool` instance indeed:
 
 ~~~clojure
-(pool/pool? POOL)
+(pg/pool? POOL)
 ;; true
 ~~~
 
 ## Closing
 
-The `close` method shuts down a pool instance. On shutdown, first, all the free
-connections get closed. Then the pool closes busy connections that were
+The `close` function shuts down a pool instance. On shutdown, first, all the
+free connections get closed. Then the pool closes busy connections that were
 borrowed. This might lead to failures in other threads, so it's worth waiting
 until the pool has zero busy connections.
 
 ~~~clojure
-(pool/close POOL)
+(pg/close POOL)
 ;; nil
 ~~~
 
 The `closed?` predicate ensures the pool has already been closed:
 
 ~~~clojure
-(pool/closed? POOL)
+(pg/closed? POOL)
 ;; true
 ~~~
 

--- a/docs/query-execute.md
+++ b/docs/query-execute.md
@@ -48,6 +48,10 @@ query like these two below or similar:
 `format`, or other functions that operate on strings. You will regret it one
 day. Use execute with parameters instead.**
 
+The `query` function accepts not a connection only but anything that implements
+the `ISource` protocol. For details, please check out the [Data Source
+Abstraction](/docs/data-source.md) section.
+
 ## Execute
 
 The `execute` function acts like `query` but has the following peculiarities:
@@ -118,6 +122,9 @@ ids.
 Both `query` and `execute` functions accept various options that affect data
 processing. Find their description in the next section.
 
-**UPD:** in a recent relese, the `execute` function caches prepared statements.
-See the [Prepared Statement Cache](/docs/prepared-statement-cache.md) section for
-more info.
+Just like `query`, the `execute` function accepts anything that implements the
+`ISource` protocol. See the [Data Source Abstraction](/docs/data-source.md)
+section for details.
+
+The `execute` function silently caches prepared statements. See the [Prepared
+Statement Cache](/docs/prepared-statement-cache.md) section for more info.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -60,11 +60,11 @@ create table demo (
 
 
 ;; Try two expressions in a single transaction
-(pg/with-tx [conn]
-  (pg/execute conn
+(pg/with-transaction [tx conn]
+  (pg/execute tx
               "delete from demo where id = $1"
               {:params [3]})
-  (pg/execute conn
+  (pg/execute tx
               "insert into demo (title) values ($1)"
               {:params ["test4"]}))
 ;; {:inserted 1}

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -40,21 +40,29 @@ will be available during transaction but won't be stored at the end.
 (pg/rollback conn)
 ~~~
 
-## The macro
+## The Macro
 
-There is a macro what handles `BEGIN`, `COMMIT`, and `ROLLBACK` logic for
-you. The `with-tx` one wraps a block of code. It opens a transaction, executes
-the body and, if there was no an exception, commits it. If there was an
-exception, the macro rolls back the transaction and re-throws it.
+There is a `with-transaction` macro which handles `BEGIN`, `COMMIT`, and
+`ROLLBACK` logic for you. The macro wraps a block of code. It opens a
+transaction, executes the body and, if there weren't exceptions, commits it. If
+there was an exception, the macro rolls back the transaction and re-throws it.
 
-The first argument of the macro is a connection object:
+The macro accepts at least two arguments:
+
+- the first one is a binding symbol, e.g. `conn` or `tx`;
+- the second one is a [Data Source](/docs/data-source.md).
+
+The macro obtains a connection from a source and binds it to the first
+argument. The transaction will occur in this connection only. To perform
+multiple actions within a transaction, pass this specific connection to
+functions that accept a connection:
 
 ~~~clojure
-(pg/with-tx [conn]
-  (pg/execute conn
+(pg/with-transaction [tx src]
+  (pg/execute tx
               "delete from test1 where name like $1"
               {:params ["Test%"]})
-  (pg/execute conn
+  (pg/execute tx
               "insert into test1 (name) values ($1)"
               {:params ["Test3"]}))
 ~~~
@@ -62,17 +70,19 @@ The first argument of the macro is a connection object:
 The macro expands into something like this:
 
 ~~~clojure
-(pg/begin conn)
-(try
-  (let [result (do <body>)]
-    (pg/commit conn)
-    result)
-  (catch Throwable e
-    (pg/rollback conn)
-    (throw e)))
+(pg/with-conn [tx src]
+  (pg/begin tx)
+  (try
+    (let [result (do <body>)]
+      (pg/commit tx)
+      result)
+    (catch Throwable e
+      (pg/rollback tx)
+      (throw e))))
 ~~~
 
-The macro accepts several optional parameters that affect a transaction, namely:
+The macro accepts an optional map of parameters that affect a transaction,
+namely:
 
 | Name               | Type              | Description                                                                  |
 |--------------------|-------------------|------------------------------------------------------------------------------|
@@ -87,8 +97,8 @@ transaction to be read only. Thus, only `SELECT` queries will work. Running
 `INSERT`, `UPDATE`, or `DELETE` will cause an exception:
 
 ~~~clojure
-(pg/with-tx [conn {:read-only? true}]
-  (pg/execute conn
+(pg/with-transaction [tx conn {:read-only? true}]
+  (pg/execute tx
               "delete from test1 where name like $1"
               {:params ["Test%"]}))
 
@@ -102,8 +112,8 @@ The `:rollback?` parameter, when set to true, rolls back a transaction even if
 it was successful. This is useful for tests:
 
 ~~~clojure
-(pg/with-tx [conn {:rollback? true}]
-  (pg/execute conn
+(pg/with-transaction [tx URI {:rollback? true}]
+  (pg/execute tx
               "delete from test1 where name like $1"
               {:params ["Test%"]}))
 
@@ -113,7 +123,7 @@ it was successful. This is useful for tests:
 ;; statement: ROLLBACK
 ~~~
 
-Above, inside the `with-tx` macro, you'll have all the rows deleted but once you
+Above, inside the `with-transaction` macro, you'll have all the rows deleted but once you
 get back, they will be there again.
 
 ## Isolation Level
@@ -131,11 +141,11 @@ transaction. The table below shows its possible values:
 Usage:
 
 ~~~clojure
-(pg/with-tx [conn {:isolation-level :serializable}]
-  (pg/execute conn
+(pg/with-transaction [tx config {:isolation-level :serializable}]
+  (pg/execute tx
               "delete from test1 where name like $1"
               {:params ["Test%"]})
-  (pg/execute conn
+  (pg/execute tx
               "insert into test1 (name) values ($1)"
               {:params ["Test3"]}))
 
@@ -157,26 +167,27 @@ refer to the [official documentation][transaction-iso] for more information.
 
 ## Nested Transactions
 
-Nested transactions happen when you put one `with-tx` inside another, for
-example:
+Nested transactions happen when you put one `with-transaction` inside another,
+for example:
 
 ~~~clojure
-(with-tx [...]          ;; 1
+(with-transaction [...]          ;; 1
   (do-this ...)
-  (with-tx [...]        ;; 2
+  (with-transaction [...]        ;; 2
     (do-that ...)))
 ~~~
 
 It's not necessary to have them both explicitly; you can easily have two nested
-functions `(do-a)` and `(do-b)` each of them driven with the `with-tx` macro:
+functions `(do-a)` and `(do-b)` each of them driven with the `with-transaction`
+macro:
 
 ~~~clojure
 (defn do-b [...]
-  (with-tx [...]
+  (with-transaction [...]
     (do-something ...)))
 
 (defn do-a [...]
-  (with-tx [...]
+  (with-transaction [...]
     (do-b ...)))
 ~~~
 
@@ -205,14 +216,15 @@ first `COMMIT` closes the transaction leaving a part of `do-a` logic being
 uncovered. Calling the second `COMMIT` won't do anything since there is no an
 active transaction any longer. It will only produce a notice.
 
-Since 0.1.17, PG2 handles this case property. The `with-tx` macro checks if the
+Since 0.1.17, PG2 handles this case property. The `with-transaction` macro checks if the
 connection is in transaction mode by calling the `(pg/in-transaction? ...)`
 function. If it's not, the macro works as before: it wraps a block of code with
 the `BEGIN/COMMIT/ROLLBACK` commands.
 
 But if the connection is already in transaction, the macro skips `BEGIN/COMMIT`
-commands leaving just the body. Thus, having two or more nested `with-tx` macros
-will produce the following sequence of SQL expressions:
+commands leaving just the body. Thus, having two or more nested
+`with-transaction` macros will produce the following sequence of SQL
+expressions:
 
 ~~~sql
 BEGIN  -- from A
@@ -223,4 +235,4 @@ COMMIT -- from A
 ~~~
 
 With this improvement, you don't need to check manually if underlying code has
-its own `with-tx` macro calls.
+its own `with-transaction` macro calls.

--- a/docs/transaction.md
+++ b/docs/transaction.md
@@ -49,12 +49,12 @@ there was an exception, the macro rolls back the transaction and re-throws it.
 
 The macro accepts at least two arguments:
 
-- the first one is a binding symbol, e.g. `conn` or `tx`;
+- the first one is a binding symbol, e.g. `conn`, `tx`, etc;
 - the second one is a [Data Source](/docs/data-source.md).
 
 The macro obtains a connection from a source and binds it to the first
 argument. The transaction will occur in this connection only. To perform
-multiple actions within a transaction, pass this specific connection to
+multiple actions within the same transaction, pass this specific connection to
 functions that accept a connection:
 
 ~~~clojure

--- a/pg-core/src/clj/pg/common.clj
+++ b/pg-core/src/clj/pg/common.clj
@@ -1,0 +1,13 @@
+(ns pg.common
+  (:import
+   org.pg.error.PGError))
+
+(set! *warn-on-reflection* true)
+
+
+(defn error!
+  ([message]
+   (throw (new PGError message)))
+
+  ([template & args]
+   (throw (new PGError (apply format template args)))))

--- a/pg-core/src/clj/pg/common.clj
+++ b/pg-core/src/clj/pg/common.clj
@@ -1,13 +1,16 @@
 (ns pg.common
+  "
+  Things needed across many namespaces.
+  "
   (:import
    org.pg.error.PGError))
 
 (set! *warn-on-reflection* true)
 
 
-(defn error!
+(defmacro error!
   ([message]
-   (throw (new PGError message)))
+   `(throw (new PGError ~message)))
 
   ([template & args]
-   (throw (new PGError (apply format template args)))))
+   `(throw (new PGError (format ~template ~@args)))))

--- a/pg-core/src/clj/pg/config.clj
+++ b/pg-core/src/clj/pg/config.clj
@@ -1,0 +1,228 @@
+(ns pg.config
+  "
+  A dedicated namespace to build an instance of the Config
+  class from a Clojure map. Apparently, this function has
+  grown vast so it's better to keep it here.
+  "
+  (:require
+   [pg.common :refer [error!]]
+   [pg.connection-uri :as uri])
+  (:import
+   org.pg.Config
+   org.pg.Config$Builder
+   org.pg.enums.SSLValidation))
+
+
+(defn ->SSLValidation
+  "
+  Coerce a Clojure value to SSLValidation enum.
+  "
+  ^SSLValidation [x]
+  (case x
+    (nil false off none no "none" "off" "no" :none :off :no)
+    SSLValidation/NONE
+
+    (default :default "default")
+    SSLValidation/DEFAULT
+
+    ;; default
+    (error! "unknown ssl validation value: %s" x)))
+
+
+(defn ->config
+  "
+  Turn a Clojure map into an instance of `Config` via `Config.Builder`.
+  First, try to parse the `connection-uri` URI string, if passed.
+  Then merge it with other parameters. Finally, build a `Config`
+  instance.
+  "
+  ^Config [params]
+
+  (let [{:keys [connection-uri
+                pg-params]}
+        params
+
+        uri-params
+        (some-> connection-uri uri/parse)
+
+        {uri-pg-params :pg-params}
+        uri-params
+
+        pg-params
+        (merge uri-pg-params pg-params)
+
+        params
+        (merge uri-params params)
+
+        {:keys [ ;; general
+                user
+                database
+                host
+                port
+                password
+
+                ;; Next.JDBC
+                dbname
+
+                ;; enc/dec format
+                binary-encode?
+                binary-decode?
+
+                ;; copy in/out
+                in-stream-buf-size
+                out-stream-buf-size
+
+                ;; handlers
+                fn-notification
+                fn-protocol-version
+                fn-notice
+
+                ;; ssl
+                use-ssl? ;; deprecated
+                ssl?
+                ssl-context
+                ssl-validation
+
+                ;; unix domain socket
+                unix-socket?
+                unix-socket-path
+
+                ;; socket
+                so-keep-alive?
+                so-tcp-no-delay?
+                so-timeout
+                so-recv-buf-size
+                so-send-buf-size
+
+                ;; logging
+                log-level
+
+                ;; json
+                ^ObjectMapper object-mapper
+
+                ;; read only
+                read-only?
+
+                ;; misc
+                cancel-timeout-ms
+                protocol-version
+
+                ;; pool
+                pool-min-size
+                pool-max-size
+                pool-expire-threshold-ms
+                pool-borrow-conn-timeout-ms
+
+                ;; types
+                type-map
+                enums
+
+                with-pgvector?]}
+        params
+
+        DB
+        (or database dbname)]
+
+    (cond-> (new Config$Builder user DB)
+
+      password
+      (.password password)
+
+      host
+      (.host host)
+
+      port
+      (.port port)
+
+      protocol-version
+      (.protocolVersion protocol-version)
+
+      (seq pg-params)
+      (.pgParams pg-params)
+
+      (some? binary-encode?)
+      (.binaryEncode binary-encode?)
+
+      (some? binary-decode?)
+      (.binaryDecode binary-decode?)
+
+      in-stream-buf-size
+      (.inStreamBufSize in-stream-buf-size)
+
+      out-stream-buf-size
+      (.outStreamBufSize out-stream-buf-size)
+
+      (some? use-ssl?)
+      (.useSSL use-ssl?)
+
+      (some? ssl?)
+      (.useSSL ssl?)
+
+      ssl-validation
+      (.sslValidation (->SSLValidation ssl-validation))
+
+      ssl-context
+      (.sslContext ssl-context)
+
+      fn-notification
+      (.fnNotification fn-notification)
+
+      fn-protocol-version
+      (.fnProtocolVersion fn-protocol-version)
+
+      fn-notice
+      (.fnNotice fn-notice)
+
+      (some? so-keep-alive?)
+      (.SOKeepAlive so-keep-alive?)
+
+      (some? so-tcp-no-delay?)
+      (.SOTCPnoDelay so-tcp-no-delay?)
+
+      so-timeout
+      (.SOTimeout so-timeout)
+
+      so-recv-buf-size
+      (.SOReceiveBufSize so-recv-buf-size)
+
+      so-send-buf-size
+      (.SOSendBufSize so-send-buf-size)
+
+      (some? unix-socket?)
+      (.useUnixSocket unix-socket?)
+
+      unix-socket-path
+      (.unixSocketPath unix-socket-path)
+
+      object-mapper
+      (.objectMapper object-mapper)
+
+      cancel-timeout-ms
+      (.cancelTimeoutMs cancel-timeout-ms)
+
+      read-only?
+      (.readOnly)
+
+      pool-min-size
+      (.poolMinSize pool-min-size)
+
+      pool-max-size
+      (.poolMaxSize pool-max-size)
+
+      pool-expire-threshold-ms
+      (.poolExpireThresholdMs pool-expire-threshold-ms)
+
+      pool-borrow-conn-timeout-ms
+      (.poolBorrowConnTimeoutMs pool-borrow-conn-timeout-ms)
+
+      type-map
+      (.typeMap type-map)
+
+      enums
+      (.enums enums)
+
+      with-pgvector?
+      (.usePGVector)
+
+      :finally
+      (.build))))

--- a/pg-core/src/clj/pg/connection_uri.clj
+++ b/pg-core/src/clj/pg/connection_uri.clj
@@ -1,5 +1,8 @@
 (ns pg.connection-uri
   "
+  A namespace to parse a connection URI string into
+  a map of config fields.
+
   Links:
   - https://jdbc.postgresql.org/documentation/use/
   "
@@ -27,7 +30,14 @@
       (error! "cannot parse long value: %s, reason: %s"
         line (ex-message e)))))
 
-(defn parse-ref [^String line]
+(defn parse-ref
+  "
+  Resolve a Clojure object by a fully qualified string
+  pointing on it (like 'org.acme.util/my-handerl').
+  Throw an error should a string is not qualified or
+  point to a missing object.
+  "
+  [^String line]
   (try
     (-> line
         symbol
@@ -69,7 +79,7 @@
 (defn parse
   "
   Parse a string URI into a map of Config options.
-  See `pg.core/->config`.
+  See `pg.config/->config`.
   "
   [^String connection-uri]
   (let [connection-uri

--- a/pg-core/src/clj/pg/core.clj
+++ b/pg-core/src/clj/pg/core.clj
@@ -55,20 +55,6 @@
 
 
 ;;
-;; Errors
-;;
-
-(defn ^:deprecated get-error-fields
-  "
-  Get a map of error fields from an instance of
-  `PGErrorResponse`. **Deprecated**, use `ex-data`
-  instead.
-  "
-  [^PGErrorResponse e]
-  (ex-data e))
-
-
-;;
 ;; Connect
 ;;
 
@@ -397,15 +383,6 @@
   "
   [^Connection conn ^PreparedStatement statement]
   (.closeStatement conn statement))
-
-
-;; TODO
-(defn ssl?
-  "
-  True if the connection is encrypted with SSL.
-  "
-  ^Boolean [^Connection conn]
-  (.isSSL conn))
 
 
 ;;
@@ -827,18 +804,6 @@
                (throw e#))))))))
 
 
-(defmacro ^:deprecated with-tx
-  "
-  **DEPRECATED**: use `with-transaction` below.
-  ---------------------------------------------
-  Acts like `with-transaction` but accepts a connection,
-  not a data source. Thus, no a binding symbol required.
-  "
-  [[conn opts] & body]
-  `(with-transaction [_# ~conn ~opts]
-     ~@body))
-
-
 (defn connection?
   "
   True of the passed option is a Connection instance.
@@ -1031,7 +996,6 @@
 ;; SSL
 ;;
 
-;; TODO
 (defn is-ssl?
   "
   True if the Connection is SSL-encrypted.
@@ -1072,4 +1036,30 @@
   "
   [[bind config] & body]
   `(with-open [~bind (pool ~config)]
+     ~@body))
+
+
+;;
+;; DEPRECATED
+;;
+
+(defn ^:deprecated get-error-fields
+  "
+  Get a map of error fields from an instance of
+  `PGErrorResponse`. **Deprecated**, use `ex-data`
+  instead.
+  "
+  [^PGErrorResponse e]
+  (ex-data e))
+
+
+(defmacro ^:deprecated with-tx
+  "
+  **DEPRECATED**: use `with-transaction` below.
+  ---------------------------------------------
+  Acts like `with-transaction` but accepts a connection,
+  not a data source. Thus, no a binding symbol required.
+  "
+  [[conn opts] & body]
+  `(with-transaction [_# ~conn ~opts]
      ~@body))

--- a/pg-core/src/clj/pg/core.clj
+++ b/pg-core/src/clj/pg/core.clj
@@ -275,7 +275,7 @@
 
 (defn execute-statement
   "
-  Execute a given prepared statement and return the result.
+  Execute a given prepared statement and return a result.
   The way the result is processed heavily depends on options.
   "
   ([^Connection conn ^PreparedStatement statement]
@@ -288,7 +288,7 @@
 (defn execute
   "
   Execute a SQL expression and return a result. Arguments:
-  - `src` is a data source (a Connection, a Pool, a map);
+  - `src` is a data source (a Connection, a Pool, a map, a URI string);
   - `sql` is a SQL string expression;
   - `opt` is a map of options.
 
@@ -354,7 +354,7 @@
   Run a SQL expression WITH NO parameters. The result
   is always sent back in text mode (binary mode doesn't
   work with the QUERY API). Arguments:
-  - `src` is a data source (a Connection, a Pool, a map);
+  - `src` is a data source (a Connection, a Pool, a map, a URI string);
   - `sql` is a SQL string without parameters (e.g. $1, etc);
   - `opt` is a map of options.
   "
@@ -587,7 +587,7 @@
 
   Arguments:
   - `tx` is a symbol which a transactional connection is bound to;
-  - `src` is a data source (a Clojure map, a Pool, a Connection).
+  - `src` is a data source (a map, a Pool, a Connection, a URI string).
 
   The third argument is an optional map of parameters:
 

--- a/pg-core/src/clj/pg/core.clj
+++ b/pg-core/src/clj/pg/core.clj
@@ -6,9 +6,7 @@
    [clojure.string :as str]
    [pg.common :refer [error!]]
    [pg.execute-params :refer [->execute-params]]
-   [pg.fold :as fold]
    [pg.config :refer [->config]]
-   [pg.oid :as oid]
    [pg.ssl #_(load a reader tag)] )
   (:import
    clojure.lang.IDeref

--- a/pg-core/src/clj/pg/core.clj
+++ b/pg-core/src/clj/pg/core.clj
@@ -955,3 +955,33 @@
 ;;
 ;; Pool?
 ;;
+
+(defn pool?
+  "
+  True if a value is a Pool instance.
+  "
+  [x]
+  (instance? Pool x))
+
+
+(defn pool
+  "
+  Run a new Pool from a config map.
+  "
+  (^Pool [^Map opt]
+   (-> opt
+       (->config)
+       (Pool/create)))
+
+  (^Pool [^String host ^Integer port ^String user ^String password ^String database]
+   (Pool/create host port user password database)))
+
+
+(defmacro with-pool
+  "
+  Execute the body while the `bind` symbol is bound
+  to a new Pool instance. Close the pool afterwards.
+  "
+  [[bind config] & body]
+  `(with-open [~bind (pool ~config)]
+     ~@body))

--- a/pg-core/src/clj/pg/core.clj
+++ b/pg-core/src/clj/pg/core.clj
@@ -880,7 +880,7 @@
 
 
 ;;
-;; DEPRECATED
+;; THE ABYSS OF DEPRECATED
 ;;
 
 (defn ^:deprecated get-error-fields
@@ -895,7 +895,7 @@
 
 (defmacro ^:deprecated with-tx
   "
-  **DEPRECATED**: use `with-transaction` below.
+  **DEPRECATED**: use `with-transaction` above.
   ---------------------------------------------
   Acts like `with-transaction` but accepts a connection,
   not a data source. Thus, no a binding symbol required.

--- a/pg-core/src/clj/pg/core.clj
+++ b/pg-core/src/clj/pg/core.clj
@@ -87,22 +87,6 @@
     "Return a connection to a source. Don't call it directly."))
 
 
-(defn connect
-  "
-  Connect to the database. Given a Clojure config map
-  or a URI string, establish a TCP connection with the
-  server and run the authentication pipeline. Returns
-  an instance of the Connection class.
-  "
-  (^Connection [src]
-   (-> src
-       (-to-config)
-       (Connection/connect)))
-
-  (^Connection [^String host ^Integer port ^String user ^String password ^String database]
-   (Connection/connect host port user password database)))
-
-
 (defmacro unsupported! [src]
   `(error! "Unsupported data source: %s" ~src))
 
@@ -173,7 +157,7 @@
     (->config {:connection-uri this}))
 
   (-borrow-connection [this]
-    (connect this))
+    (-> this -to-config Connection/connect))
 
   (-return-connection [this conn]
     (-close conn))
@@ -196,7 +180,7 @@
     (->config this))
 
   (-borrow-connection [this]
-    (connect this))
+    (-> this -to-config Connection/connect))
 
   (-return-connection [this conn]
     (-close conn))
@@ -274,6 +258,20 @@
 ;;
 ;; Connection
 ;;
+
+(defn connect
+  "
+  Connect to the database. Given a Clojure config map
+  or a URI string, establish a TCP connection with the
+  server and run the authentication pipeline. Returns
+  an instance of the Connection class.
+  "
+  (^Connection [src]
+   (-borrow-connection src))
+
+  (^Connection [^String host ^Integer port ^String user ^String password ^String database]
+   (Connection/connect host port user password database)))
+
 
 (defmacro with-connection
   "

--- a/pg-core/src/clj/pg/execute_params.clj
+++ b/pg-core/src/clj/pg/execute_params.clj
@@ -1,0 +1,204 @@
+(ns pg.execute-params
+  "
+  A dedicated namespace to build an instance of the
+  `ExecuteParams` class from a Clojure map.
+  "
+  (:require
+   [clojure.string :as str]
+   [pg.fold :as fold])
+  (:import
+   clojure.lang.Keyword
+   java.util.List
+   java.util.Map
+   org.pg.ExecuteParams))
+
+
+(defn ->kebab
+  "
+  Turn a string column name into into  a kebab-case
+  formatted keyword.
+  "
+  ^Keyword [^String column]
+  (-> column (str/replace #"_" "-") keyword))
+
+
+(defn ->execute-params
+  "
+  Make an instance of ExecuteParams from a Clojure map.
+  "
+  ^ExecuteParams [^Map opt]
+
+  (if (or (nil? opt) (= opt {}))
+    ExecuteParams/INSTANCE
+
+    (let [{:keys [^List params
+                  oids
+
+                  ;; portal
+                  max-rows
+
+                  ;; keys
+                  kebab-keys?
+                  fn-key
+
+                  ;; streams
+                  output-stream
+                  input-stream
+
+                  ;; fold/reduce
+                  as
+                  first
+                  first? ;; for backward compatibility
+                  map
+                  index-by
+                  group-by
+                  kv
+                  java
+                  run
+                  column
+                  columns
+                  table
+                  to-edn
+                  to-json
+                  reduce
+                  into
+
+                  ;; format
+                  binary-encode?
+                  binary-decode?
+
+                  ;; copy csv
+                  csv-null
+                  csv-sep
+                  csv-end
+
+                  ;; copy general
+                  copy-buf-size
+                  ^CopyFormat copy-format
+                  copy-csv?
+                  copy-bin?
+                  copy-tab?
+                  copy-in-rows
+                  copy-in-maps
+                  copy-in-keys]}
+          opt]
+
+      (cond-> (ExecuteParams/builder)
+
+        params
+        (.params params)
+
+        oids
+        (.OIDs oids)
+
+        max-rows
+        (.maxRows max-rows)
+
+        fn-key
+        (.fnKeyTransform fn-key)
+
+        output-stream
+        (.outputStream output-stream)
+
+        input-stream
+        (.inputStream input-stream)
+
+        kebab-keys?
+        (.fnKeyTransform ->kebab)
+
+        ;;
+        ;; reducers
+        ;;
+        as
+        (.reducer as)
+
+        (or first first?)
+        (.reducer fold/first)
+
+        map
+        (.reducer (fold/map map))
+
+        index-by
+        (.reducer (fold/index-by index-by))
+
+        group-by
+        (.reducer (fold/group-by group-by))
+
+        kv
+        (.reducer (fold/kv (clojure.core/first kv) (second kv)))
+
+        run
+        (.reducer (fold/run run))
+
+        column
+        (.reducer (fold/column column))
+
+        columns
+        (.reducer (fold/columns columns))
+
+        table
+        (.reducer (fold/table))
+
+        java
+        (.reducer fold/java)
+
+        to-edn
+        (.reducer (fold/to-edn to-edn))
+
+        to-json
+        (.reducer (fold/to-json to-json))
+
+        reduce
+        (.reducer (fold/reduce (clojure.core/first reduce)
+                               (second reduce)))
+
+        into
+        (.reducer (fold/into (clojure.core/first into)
+                             (second into)))
+
+        ;; end reducers
+
+        (some? binary-encode?)
+        (.binaryEncode binary-encode?)
+
+        (some? binary-decode?)
+        (.binaryDecode binary-decode?)
+
+        csv-null
+        (.CSVNull csv-null)
+
+        csv-sep
+        (.CSVCellSep csv-sep)
+
+        csv-end
+        (.CSVLineSep csv-end)
+
+        oids
+        (.OIDs oids)
+
+        copy-csv?
+        (.setCSV)
+
+        copy-bin?
+        (.setBin)
+
+        copy-tab?
+        (.setBin)
+
+        copy-format
+        (.copyFormat copy-format)
+
+        copy-buf-size
+        (.copyBufSize copy-buf-size)
+
+        copy-in-rows
+        (.copyInRows copy-in-rows)
+
+        copy-in-maps
+        (.copyInMaps copy-in-maps)
+
+        copy-in-keys
+        (.copyInKeys copy-in-keys)
+
+        :finally
+        (.build)))))

--- a/pg-core/src/clj/pg/jdbc.clj
+++ b/pg-core/src/clj/pg/jdbc.clj
@@ -28,8 +28,8 @@
   to use as there is a chance to leave the connection not
   closed. Consider `pg/on-connection` instead.
   "
-  ^Connection [source]
-  (pg/-borrow-connection source))
+  ^Connection [src]
+  (pg/connect src))
 
 
 (defmacro on-connection [[bind source] & body]

--- a/pg-core/src/clj/pg/jdbc.clj
+++ b/pg-core/src/clj/pg/jdbc.clj
@@ -12,6 +12,7 @@
    org.pg.Pool)
   (:require
    [clojure.set :as set]
+   [pg.common :refer [error!]]
    [pg.core :as pg]
    [pg.pool :as pool]))
 
@@ -32,7 +33,7 @@
 
 
 (defmacro on-connection [[bind source] & body]
-  `(pg/on-connection [~bind ~source]
+  `(pg/with-connection [~bind ~source]
      ~@body))
 
 
@@ -46,7 +47,7 @@
     pg/execute-statement
 
     :else
-    (pg/error! "Wrong execute expression: %s" expr)))
+    (error! "Wrong execute expression: %s" expr)))
 
 
 (defn execute!
@@ -68,7 +69,7 @@
          fn-execute
          (->fn-execute expr)]
 
-     (pg/on-connection [conn source]
+     (pg/with-conn [conn source]
        (fn-execute conn
                    expr
                    (-> opt-defaults
@@ -90,7 +91,7 @@
          fn-execute
          (->fn-execute expr)]
 
-     (pg/on-connection [conn source]
+     (pg/with-conn [conn source]
        (fn-execute conn
                    expr
                    (-> opt-defaults
@@ -123,7 +124,7 @@
 
   ([source sql-vec opt]
    (let [[sql & params] sql-vec]
-     (pg/on-connection [conn source]
+     (pg/with-conn [conn source]
        (pg/prepare conn
                    sql
                    (assoc opt :params params))))))
@@ -134,7 +135,7 @@
   Performs batch execution on the server side (TBD).
   "
   [conn sql opts]
-  (pg/error! "execute-batch! is not imiplemented"))
+  (error! "execute-batch! is not imiplemented"))
 
 
 (defn remap-tx-opts [jdbc-opt]
@@ -163,7 +164,7 @@
   Return the result of the body block.
   "
   [[bind source opts] & body]
-  `(pg/on-connection [~bind ~source]
+  `(pg/with-conn [~bind ~source]
      (pg/with-tx [~bind
                   ~@(when opts
                       `[(remap-tx-opts ~opts)])]

--- a/pg-core/src/clj/pg/pool.clj
+++ b/pg-core/src/clj/pg/pool.clj
@@ -26,42 +26,36 @@
    org.pg.Pool))
 
 
-(defn id
+(defn ^:deprecated id
   "
-  Get a unique ID of the pool.
-  "
-  ^UUID [^Pool pool]
-  (.getId pool))
-
-
-(defn pool?
-  "
-  True if a value is a Pool instance.
-  "
-  [x]
-  (instance? Pool x))
-
-
-(defn pool
-  "
-  Run a new Pool from a config map.
-  "
-  (^Pool [^Map opt]
-   (-> opt
-       (->config)
-       (Pool/create)))
-
-  (^Pool [^String host ^Integer port ^String user ^String password ^String database]
-   (Pool/create host port user password database)))
-
-
-(defn close
-  "
-  Close the pool by terminating all the connections,
-  both free and used.
+  Deprecated! Use `pg.core/id`.
   "
   [^Pool pool]
-  (.close pool))
+  (pg/id pool))
+
+
+(defn ^:deprecated pool?
+  "
+  Deprecated! Use `pg.core/pool?`.
+  "
+  [x]
+  (pg/pool? x))
+
+
+(defn ^:deprecated pool
+  "
+  Deprecated! Use `pg.core/pool`.
+  "
+  ^Pool [& args]
+  (apply pg/pool args))
+
+
+(defn ^:deprecated close
+  "
+  Deprecated! Use `pg.core/close`.
+  "
+  [^Pool pool]
+  (pg/close pool))
 
 
 (defn used-count
@@ -80,56 +74,28 @@
   (.freeCount pool))
 
 
-(defmacro with-pool
+(defmacro ^:deprecated with-pool
   "
-  Execute the body while the `bind` symbol is bound
-  to a new Pool instance. Close the pool afterwards.
+  Deprecated! Use `pg.core/with-pool`.
   "
-  [[bind config] & body]
-  `(with-open [~bind (pool ~config)]
-     ~@body))
+  [& args]
+  `(pg/with-pool ~@args))
 
 
-(defn borrow-connection
+(defmacro ^:deprecated with-connection
   "
-  Borrow a connection from a pool.
+  Deprecated! Use `pg.core/with-connection`.
   "
-  ^Connection [^Pool pool]
-  (.borrowConnection pool))
+  [& args]
+  `(pg/with-connection ~@args))
 
 
-(defmacro with-connection
+(defmacro ^:deprecated with-conn
   "
-  Execute the body while the `bind` symbol is bound
-  to a borrowed Connection instance. The connection
-  is marked is busy and won't be available for other
-  consumers. Return the connection to the pool when
-  exiting the macro.
-
-  When no connections available, throw an exception.
+  Deprecated! Use `pg.core/with-conn`.
   "
-  [[bind pool] & body]
-  (let [POOL
-        (with-meta (gensym "POOL")
-          {:tag `Pool})]
-    `(let [~POOL
-           ~pool
-
-           ~(with-meta bind {:tag `Connection})
-           (.borrowConnection ~POOL)]
-       (try
-         ~@body
-         (finally
-           (.returnConnection ~POOL ~bind))))))
-
-
-(defmacro with-conn
-  "
-  Just a shorter version of `with-connection`.
-  "
-  [[bind pool] & body]
-  `(with-connection [~bind ~pool]
-     ~@body))
+  [& args]
+  `(pg/with-conn ~@args))
 
 
 (defn stats
@@ -141,12 +107,12 @@
    :used (used-count pool)})
 
 
-(defn closed?
+(defn ^:deprecated closed?
   "
-  True if the pool has been closed before.
+  Deprecated! Use `pg.core/closed?`
   "
-  ^Boolean [^Pool pool]
-  (.isClosed pool))
+  [^Pool pool]
+  (pg/closed? pool))
 
 
 (defn replenish-connections

--- a/pg-core/src/clj/pg/pool.clj
+++ b/pg-core/src/clj/pg/pool.clj
@@ -69,7 +69,7 @@
 
 
 ;;
-;; DEPRECATED
+;; THE ABYSS OF DEPRECATED
 ;;
 
 (defn ^:deprecated id

--- a/pg-core/src/clj/pg/pool.clj
+++ b/pg-core/src/clj/pg/pool.clj
@@ -16,6 +16,7 @@
   are closed; Connections that are in a transaction are rolled back.
   "
   (:require
+   [pg.config :refer [->config]]
    [pg.core :as pg])
   (:import
    java.io.Writer
@@ -46,7 +47,9 @@
   Run a new Pool from a config map.
   "
   (^Pool [^Map opt]
-   (Pool/create (pg/->config opt)))
+   (-> opt
+       (->config)
+       (Pool/create)))
 
   (^Pool [^String host ^Integer port ^String user ^String password ^String database]
    (Pool/create host port user password database)))
@@ -144,11 +147,6 @@
   "
   ^Boolean [^Pool pool]
   (.isClosed pool))
-
-
-(defmethod print-method Pool
-  [^Pool pool ^Writer writer]
-  (.write writer (.toString pool)))
 
 
 (defn replenish-connections

--- a/pg-core/src/clj/pg/pool.clj
+++ b/pg-core/src/clj/pg/pool.clj
@@ -26,6 +26,52 @@
    org.pg.Pool))
 
 
+(defn used-count
+  "
+  Return the current number of busy connections.
+  "
+  ^Integer [^Pool pool]
+  (.usedCount pool))
+
+
+(defn free-count
+  "
+  Return the current number of free connections.
+  "
+  ^Integer [^Pool pool]
+  (.freeCount pool))
+
+
+(defn stats
+  "
+  Return both free and used connection amount as a map.
+  "
+  [^Pool pool]
+  {:free (free-count pool)
+   :used (used-count pool)})
+
+
+(defn replenish-connections
+  "
+  Forcibly run a task that determines how many new
+  free connections should be created, and creates them.
+  The number is calculated as follows:
+
+  gap = min-size - size(free-conns) - size(used-conns)
+
+  When gap is > 0, the corresponding number of free connections
+  is created.
+
+  Blocks the pool.
+  "
+  [^Pool pool]
+  (.replenishConnections pool))
+
+
+;;
+;; DEPRECATED
+;;
+
 (defn ^:deprecated id
   "
   Deprecated! Use `pg.core/id`.
@@ -57,23 +103,6 @@
   [^Pool pool]
   (pg/close pool))
 
-
-(defn used-count
-  "
-  Return the current number of busy connections.
-  "
-  ^Integer [^Pool pool]
-  (.usedCount pool))
-
-
-(defn free-count
-  "
-  Return the current number of free connections.
-  "
-  ^Integer [^Pool pool]
-  (.freeCount pool))
-
-
 (defmacro ^:deprecated with-pool
   "
   Deprecated! Use `pg.core/with-pool`.
@@ -98,35 +127,9 @@
   `(pg/with-conn ~@args))
 
 
-(defn stats
-  "
-  Return both free and used connection amount as a map.
-  "
-  [^Pool pool]
-  {:free (free-count pool)
-   :used (used-count pool)})
-
-
 (defn ^:deprecated closed?
   "
   Deprecated! Use `pg.core/closed?`
   "
   [^Pool pool]
   (pg/closed? pool))
-
-
-(defn replenish-connections
-  "
-  Forcibly run a task that determines how many new
-  free connections should be created, and creates them.
-  The number is calculated as follows:
-
-  gap = min-size - size(free-conns) - size(used-conns)
-
-  When gap is > 0, the corresponding number of free connections
-  is created.
-
-  Blocks the pool.
-  "
-  [^Pool pool]
-  (.replenishConnections pool))

--- a/pg-core/src/clj/pg/source.clj
+++ b/pg-core/src/clj/pg/source.clj
@@ -1,0 +1,210 @@
+(ns pg.source
+  "
+  A dedicated namespace for the ISource
+  abstraction and its implementations.
+  "
+  (:require
+   [pg.config :refer [->config]]
+   [pg.common :refer [error!]])
+  (:import
+   clojure.lang.IPersistentMap
+   org.pg.Connection
+   org.pg.Pool
+   org.pg.Config))
+
+
+(defmacro unsupported! [src]
+  `(error! "Unsupported data source: %s" ~src))
+
+
+(defprotocol ISource
+  "
+  A set of actions that can be applied to any kind
+  of a data source: a Clojure map, a Config object,
+  a Connection, a Pool instance, or a URI string.
+  "
+
+  (-id ^UUID [this]
+    "Get a unique ID of a data source.")
+
+  (-closed? [this]
+    "True if the source has been closed.")
+
+  (-clone [this]
+    "Create a new instance of this data source.")
+
+  (-close [this]
+    "Close a data source")
+
+  (-to-config ^Config [this]
+    "Turn this object into a Config instance.")
+
+  (-borrow-connection [this]
+    "Obtain a connection from a source. Don't call it directly.")
+
+  (-return-connection [this conn]
+    "Return a connection to a source. Don't call it directly."))
+
+
+(extend-protocol ISource
+
+  Connection
+
+  (-id ^UUID [this]
+    (.getId this))
+
+  (-closed? [this]
+    (.isClosed this))
+
+  (-clone [this]
+    (Connection/clone this))
+
+  (-close [this]
+    (.close this))
+
+  (-to-config [this]
+    (.getConfig this))
+
+  (-borrow-connection [this]
+    this)
+
+  (-return-connection [this conn]
+    nil)
+
+  Pool
+
+  (-id [this]
+    (.getId this))
+
+  (-closed? [this]
+    (.isClosed this))
+
+  (-clone [this]
+    (Pool/clone this))
+
+  (-close [this]
+    (.close this))
+
+  (-to-config [this]
+    (.getConfig this))
+
+  (-borrow-connection [this]
+    (.borrowConnection this))
+
+  (-return-connection [this conn]
+    (.returnConnection this conn))
+
+  String
+
+  (-id [this]
+    nil)
+
+  (-closed? [this]
+    false)
+
+  (-clone [this]
+    this)
+
+  (-close [this]
+    nil)
+
+  (-to-config [this]
+    (->config {:connection-uri this}))
+
+  (-borrow-connection [this]
+    (-> this -to-config Connection/connect))
+
+  (-return-connection [this conn]
+    (-close conn))
+
+  IPersistentMap
+
+  (-id [this]
+    nil)
+
+  (-closed? [this]
+    false)
+
+  (-clone [this]
+    this)
+
+  (-close [this]
+    nil)
+
+  (-to-config [this]
+    (->config this))
+
+  (-borrow-connection [this]
+    (-> this -to-config Connection/connect))
+
+  (-return-connection [this conn]
+    (-close conn))
+
+  Config
+
+  (-id [this]
+    nil)
+
+  (-closed? [this]
+    false)
+
+  (-clone [this]
+    this)
+
+  (-close [this]
+    nil)
+
+  (-to-config [this]
+    this)
+
+  (-borrow-connection [this]
+    (Connection/connect this))
+
+  (-return-connection [this conn]
+    (-close conn))
+
+  Object
+
+  (-id [this]
+    (unsupported! this))
+
+  (-closed? [this]
+    (unsupported! this))
+
+  (-clone [this]
+    (unsupported! this))
+
+  (-close [this]
+    (unsupported! this))
+
+  (-borrow-connection [this]
+    (unsupported! this))
+
+  (-to-config [this]
+    (unsupported! this))
+
+  (-return-connection [this conn]
+    (unsupported! this))
+
+  nil
+
+  (-id [this]
+    (unsupported! this))
+
+  (-closed? [this]
+    (unsupported! this))
+
+  (-clone [this]
+    (unsupported! this))
+
+  (-close [this]
+    (unsupported! this))
+
+  (-to-config [this]
+    (unsupported! this))
+
+  (-borrow-connection [this]
+    (unsupported! this))
+
+  (-return-connection [this conn]
+    (unsupported! this)))

--- a/pg-core/src/java/org/pg/Pool.java
+++ b/pg-core/src/java/org/pg/Pool.java
@@ -31,7 +31,7 @@ public final class Pool implements AutoCloseable {
     }
 
     @SuppressWarnings("unused")
-    public Pool clone(final Pool other) {
+    public static Pool clone(final Pool other) {
         return Pool.create(other.getConfig());
     }
 

--- a/pg-core/src/java/org/pg/Pool.java
+++ b/pg-core/src/java/org/pg/Pool.java
@@ -15,7 +15,7 @@ public final class Pool implements AutoCloseable {
     private boolean isClosed = false;
     private final static System.Logger logger = System.getLogger(Pool.class.getCanonicalName());
     private final TryLock lock = new TryLock();
-    
+
     @Override
     public boolean equals (Object other) {
         return other instanceof Pool && id.equals(((Pool) other).id);
@@ -24,6 +24,15 @@ public final class Pool implements AutoCloseable {
     @Override
     public int hashCode () {
         return this.id.hashCode();
+    }
+
+    public Config getConfig () {
+        return config;
+    }
+
+    @SuppressWarnings("unused")
+    public Pool clone(final Pool other) {
+        return Pool.create(other.getConfig());
     }
 
     public void replenishConnections() {

--- a/pg-core/test/pg/client_test.clj
+++ b/pg-core/test/pg/client_test.clj
@@ -344,8 +344,10 @@ from
 
 (deftest test-client-with-tx-check
   (pg/with-connection [conn *CONFIG-TXT*]
-    (pg/with-tx [conn]
-      (is (pg/connection? conn)))))
+    (pg/with-transaction [tx conn]
+      (is (pg/connection? tx))
+      (is (pg/connection? conn))
+      (is (= tx conn)))))
 
 
 (deftest test-client-with-transaction-ok

--- a/pg-core/test/pg/client_test.clj
+++ b/pg-core/test/pg/client_test.clj
@@ -4285,6 +4285,24 @@ copy (select s.x as X from generate_series(1, 3) as s(x)) TO STDOUT WITH (FORMAT
         (is (= [{:num 1}] res))))))
 
 
+(deftest test-data-source
+
+  (let [res1
+        (pg/query *CONFIG-TXT* "select 1 as num")
+
+        res2
+        (pg/execute *CONFIG-TXT* "select 1 as num")]
+
+    (is (= [{:num 1}] res1))
+    (is (= [{:num 1}] res2))
+
+    (pg/with-transaction [tx *CONFIG-TXT* {:read-only? true
+                                           :rollback? true
+                                           :isolation-level :serializable}]
+      (is (pg/connection? tx))
+      (pg/query tx "select 1 as num"))))
+
+
 #_
 (deftest test-hstore-bin
   (pg/with-conn [conn *CONFIG-BIN*]

--- a/pg-core/test/pg/config_test.clj
+++ b/pg-core/test/pg/config_test.clj
@@ -2,6 +2,7 @@
   (:import org.pg.Config)
   (:require
    [clojure.test :refer [deftest is testing]]
+   [pg.config :as config]
    [pg.connection-uri :as uri]
    [pg.core :as pg]))
 
@@ -35,7 +36,7 @@
    (options->map options FIELDS_MIN))
 
   ([options fields]
-   (-> options pg/->config (record->map fields))))
+   (-> options config/->config (record->map fields))))
 
 (deftest test-config-minimal
   (is (= {:user "testuser",

--- a/pg-core/test/pg/jdbc_test.clj
+++ b/pg-core/test/pg/jdbc_test.clj
@@ -39,7 +39,7 @@
     (is false)
     (catch Throwable e
       (is true)
-      (is (= "Connection source cannot be null"
+      (is (= "Unsupported data source: null"
              (ex-message e))))))
 
 

--- a/pg-core/test/pg/pool_test.clj
+++ b/pg-core/test/pg/pool_test.clj
@@ -430,3 +430,16 @@
 
     (is (= {:free 2, :used 0}
            (pool/stats pool)))))
+
+
+(deftest test-pool-pg-namespace
+  (pg/with-pool [pool *CONFIG*]
+    (pg/with-connection [conn pool]
+      (let [res (pg/execute conn "select 1 as one")]
+        (is (= [{:one 1}] res))))))
+
+
+(deftest test-pool-as-source
+  (with-open [pool (pg/pool *CONFIG*)]
+    (let [res (pg/execute pool "select 1 as one")]
+      (is (= [{:one 1}] res)))))

--- a/pg-core/test/pg/pool_test.clj
+++ b/pg-core/test/pg/pool_test.clj
@@ -447,6 +447,10 @@
   (pg/with-pool [pool *CONFIG*]
     (pg/with-connection [conn pool]
       (let [res (pg/execute conn "select 1 as one")]
+        (is (= [{:one 1}] res)))))
+  (pg/with-pool [pool *CONFIG*]
+    (pg/with-transaction [tx pool]
+      (let [res (pg/execute tx "select 1 as one")]
         (is (= [{:one 1}] res))))))
 
 

--- a/pg-core/test/pg/pool_test.clj
+++ b/pg-core/test/pg/pool_test.clj
@@ -8,12 +8,23 @@
    [pg.pool :as pool]))
 
 
+(def USER "test")
+(def PASS "test")
+(def HOST "127.0.0.1")
+(def PORT 10130)
+(def DATABASE "test")
+
+
 (def ^:dynamic *CONFIG*
-  {:host "127.0.0.1"
-   :port 10130
-   :user "test"
-   :password "test"
-   :database "test"})
+  {:host HOST
+   :port PORT
+   :user USER
+   :password PASS
+   :database DATABASE})
+
+
+(def URI
+  (format "postgresql://%s:%s@%s:%s/%s" USER PASS HOST PORT DATABASE))
 
 
 (deftest test-pool-it-works
@@ -440,6 +451,15 @@
 
 
 (deftest test-pool-as-source
+
   (with-open [pool (pg/pool *CONFIG*)]
     (let [res (pg/execute pool "select 1 as one")]
+      (is (= [{:one 1}] res))))
+
+  (with-open [pool (pg/pool URI)]
+    (let [res (pg/execute pool "select 1 as one")]
+      (is (= [{:one 1}] res))))
+
+  (pg/with-pool [pool URI]
+    (let [res (pg/query pool "select 1 as one")]
       (is (= [{:one 1}] res)))))

--- a/pg-core/test/pg/pool_test.clj
+++ b/pg-core/test/pg/pool_test.clj
@@ -444,10 +444,12 @@
 
 
 (deftest test-pool-pg-namespace
+
   (pg/with-pool [pool *CONFIG*]
     (pg/with-connection [conn pool]
       (let [res (pg/execute conn "select 1 as one")]
         (is (= [{:one 1}] res)))))
+
   (pg/with-pool [pool *CONFIG*]
     (pg/with-transaction [tx pool]
       (let [res (pg/execute tx "select 1 as one")]

--- a/pg-honey/src/pg/honey.clj
+++ b/pg-honey/src/pg/honey.clj
@@ -50,7 +50,7 @@
 
    (let [[sql]
          (format sql-map honey)]
-     (pg/on-connection [conn src]
+     (pg/with-conn [conn src]
        (pg/query conn sql opt)))))
 
 
@@ -73,7 +73,7 @@
               (map first)
               (str/join "; "))]
 
-     (pg/on-connection [conn src]
+     (pg/with-conn [conn src]
        (pg/query conn sql opt)))))
 
 
@@ -98,7 +98,7 @@
   ([src sql-map {:as opt :keys [honey]}]
    (let [[sql & params]
          (format sql-map honey)]
-     (pg/on-connection [conn src]
+     (pg/with-conn [conn src]
        (pg/execute conn
                    sql
                    (assoc opt :params params))))))
@@ -125,7 +125,7 @@
   ([src sql-map {:as opt :keys [honey]}]
    (let [[sql & params]
          (format sql-map honey)]
-     (pg/on-connection [conn src]
+     (pg/with-conn [conn src]
        (pg/prepare conn
                    sql
                    (assoc opt :params params))))))

--- a/pg-hugsql/src/pg/hugsql.clj
+++ b/pg-hugsql/src/pg/hugsql.clj
@@ -72,7 +72,7 @@
               (merge opt)
               (assoc :params params))]
 
-      (pg/on-connection [conn db]
+      (pg/with-conn [conn db]
         (pg/execute conn sql opt-full))))
 
   (query [this db sqlvec options]

--- a/todo.md
+++ b/todo.md
@@ -1,8 +1,5 @@
 
 - common API protocol
-  - function accept src
-  - better with-transaction macro
-  - deprecate with-tx?
   - deprecate pool?
   - check docstrings
   - add tests

--- a/todo.md
+++ b/todo.md
@@ -1,4 +1,12 @@
 
+- common API protocol
+  - function accept src
+  - better with-transaction macro
+  - deprecate with-tx?
+  - deprecate pool?
+  - check docstrings
+  - add tests
+
 - ssl:
   - switch to ssl by default?
   - ssl 3rd-party tests
@@ -8,10 +16,10 @@
 
 - user & database default values?
 
+- linting (kondo + clfjmt)
+
 - prep stmt: track pid, conn-id
 - prep stmt: check if belongs?
-
-- common API protocol?
 
 use PG* env vars
 

--- a/todo.md
+++ b/todo.md
@@ -2,6 +2,7 @@
 - common API protocol
   - check docstrings
   - update/add docs
+  - connect/pool URI
 
 - connect
   - from map

--- a/todo.md
+++ b/todo.md
@@ -3,6 +3,8 @@
   - deprecate pool?
   - check docstrings
   - add tests
+  - TODO for ssl function
+  - `-id`, `-close`, etc methods?
 
 - ssl:
   - switch to ssl by default?

--- a/todo.md
+++ b/todo.md
@@ -1,8 +1,6 @@
 
 - common API protocol
-  - check docstrings
   - update/add docs
-  - connect/pool URI
 
 - connect
   - from map

--- a/todo.md
+++ b/todo.md
@@ -1,11 +1,7 @@
 
 - common API protocol
-  - deprecate pool?
   - check docstrings
-  - add tests
-  - TODO for ssl function
-  - `-id`, `-close`, etc methods?
-  - deprecated section (core/pool)
+  - update/add docs
 
 - ssl:
   - switch to ssl by default?

--- a/todo.md
+++ b/todo.md
@@ -1,13 +1,4 @@
 
-- common API protocol
-  - update/add docs
-
-- connect
-  - from map
-  - from string
-  - from URL/URI
-  - from File?
-
 - user & database default values?
 
 - linting (kondo + clfjmt)
@@ -21,11 +12,8 @@
 - geom types: json, edn
 - geom types: toString -> toSQL
 
-
 - prep stmt: track pid, conn-id
 - prep stmt: check if belongs?
-
-
 
 .~/.pgpass
 https://www.postgresql.org/docs/current/libpq-pgpass.html

--- a/todo.md
+++ b/todo.md
@@ -3,26 +3,30 @@
   - check docstrings
   - update/add docs
 
-- ssl:
-  - switch to ssl by default?
-  - ssl 3rd-party tests
-
 - connect
+  - from map
   - from string
   - from URL/URI
   - from File?
-
-- geom types: json, edn
-- geom types: toString -> toSQL
 
 - user & database default values?
 
 - linting (kondo + clfjmt)
 
+- use PG* env vars
+
+- ssl:
+  - switch to ssl by default?
+  - ssl 3rd-party tests
+
+- geom types: json, edn
+- geom types: toString -> toSQL
+
+
 - prep stmt: track pid, conn-id
 - prep stmt: check if belongs?
 
-use PG* env vars
+
 
 .~/.pgpass
 https://www.postgresql.org/docs/current/libpq-pgpass.html

--- a/todo.md
+++ b/todo.md
@@ -5,10 +5,16 @@
   - add tests
   - TODO for ssl function
   - `-id`, `-close`, etc methods?
+  - deprecated section (core/pool)
 
 - ssl:
   - switch to ssl by default?
   - ssl 3rd-party tests
+
+- connect
+  - from string
+  - from URL/URI
+  - from File?
 
 - geom types: json, edn
 - geom types: toString -> toSQL


### PR DESCRIPTION
This PR introduces vast refactoring.

The main problem it addresses is that before, functions like `query` or `execute` accepted a Connection object only. And at some point, it has become inconvenient. For example, I have a Pool object, and every time I want to query something, first I have to fetch a connection and pass it into the function as follows:

```
(defn do-something [pool]
  (pool/with-conn [conn pool]
    (let [result (pg/query conn "select ...")])))
```

Some people can mix a connection with a pool, and pass a connection into the function, which will lead to an error.

This PR brings something that is common in next.jdbc: protocols. There is a single ISource protocol that gets extended by the following types:

- clojure map (clojure config)
- Connection
- Pool
- Config (java)
- URI String

Functions like `query` and `execute` accept not a connection any longer but any of these objects listed above. Also, now it's possible to create a connection or a pool not from a Clojure map, but from a URI as well.

I hope the new docs cover my intentions. Also, long Clojure->Java building functions are moved to separate namespaces to save lines.

cc @jgdavey so you're aware of these changes.





