### PR TITLE
Update pollNotifications to avoid sending query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - RowMap: implement Indexed and IDeref interfaces
 - #50 Use Executor rather than ExecutorService @jgdavey
 - Refactor CodecParams class (make it mutable)
+- #49 Update pollNotifications to avoid sending query @jgdavey
 
 ## 0.1.33
 

--- a/pg-core/src/java/org/pg/Connection.java
+++ b/pg-core/src/java/org/pg/Connection.java
@@ -1416,9 +1416,18 @@ public final class Connection implements AutoCloseable {
     @SuppressWarnings("unused")
     public int pollNotifications() {
         try (TryLock ignored = lock.get()) {
-            final String sql = "";
-            sendQuery(sql);
-            final Result res = interact(sql);
+            final Result res = new Result(ExecuteParams.INSTANCE, "");
+            while ( IOTool.available(inStream) > 0 ) {
+                final IServerMessage msg = readMessage(res.hasException());
+                if ( msg instanceof NotificationResponse ||
+                     msg instanceof NoticeResponse ||
+                     msg instanceof ParameterStatus ) {
+                    handleMessage(msg, res);
+                } else {
+                    throw new PGError("Unexpected message: %s", msg);
+                }
+            }
+            res.maybeThrowError();
             return res.getNotificationCount();
         }
     }

--- a/pg-core/src/java/org/pg/Connection.java
+++ b/pg-core/src/java/org/pg/Connection.java
@@ -1416,15 +1416,15 @@ public final class Connection implements AutoCloseable {
     @SuppressWarnings("unused")
     public int pollNotifications() {
         try (TryLock ignored = lock.get()) {
-            final Result res = new Result(ExecuteParams.INSTANCE, "");
-            while ( IOTool.available(inStream) > 0 ) {
+            final Result res = new Result(ExecuteParams.INSTANCE, "--pollNotifications");
+            while (IOTool.available(inStream) > 0) {
                 final IServerMessage msg = readMessage(res.hasException());
-                if ( msg instanceof NotificationResponse ||
-                     msg instanceof NoticeResponse ||
-                     msg instanceof ParameterStatus ) {
+                if (   msg instanceof NotificationResponse
+                    || msg instanceof NoticeResponse
+                    || msg instanceof ParameterStatus) {
                     handleMessage(msg, res);
                 } else {
-                    throw new PGError("Unexpected message: %s", msg);
+                    throw new PGError("Unexpected message in pollNotifications: %s", msg);
                 }
             }
             res.maybeThrowError();

--- a/pg-core/src/java/org/pg/util/IOTool.java
+++ b/pg-core/src/java/org/pg/util/IOTool.java
@@ -75,6 +75,16 @@ public final class IOTool {
         }
     }
 
+    public static int available(
+        final InputStream inputStream
+    ) {
+        try {
+            return inputStream.available();
+        } catch (IOException e) {
+            throw new PGErrorIO(e, "cannot read from the input stream");
+        }
+    }
+
     public static BufferedInputStream wrapBuf(final InputStream in, final int size) {
         if (in instanceof final BufferedInputStream b) {
             return b;

--- a/pg-core/src/java/org/pg/util/IOTool.java
+++ b/pg-core/src/java/org/pg/util/IOTool.java
@@ -65,9 +65,7 @@ public final class IOTool {
         }
     }
 
-    public static int read (
-            final InputStream inputStream
-    ) {
+    public static int read (final InputStream inputStream) {
         try {
             return inputStream.read();
         } catch (final IOException e) {
@@ -75,13 +73,11 @@ public final class IOTool {
         }
     }
 
-    public static int available(
-        final InputStream inputStream
-    ) {
+    public static int available(final InputStream inputStream) {
         try {
             return inputStream.available();
         } catch (IOException e) {
-            throw new PGErrorIO(e, "cannot read from the input stream");
+            throw new PGErrorIO(e, "input stream is not available");
         }
     }
 


### PR DESCRIPTION
Since this method was already of questionable value (especially given the recent improvements to listen/notify handling in #45 ), changing its implementation seems worthwhile.

The main idea here is to avoid sending an unnecessary request to the server. Instead, if there is unhandled messages on the read side of things, they are almost definitely asynchronous things (notifications or notices). The spec does allow ParameterStatus to come asynchronously as well.

If, somehow, the connection is in such a strange state that we didn't previously wait for the "ready" message, then those unread messages (data or otherwise) will show up here and throw an exception. Although, an argument could be made that they would throw an exception the next time a normal query were to occur. Even if unnecessary or exceedingly rare, including these message IServerMessage instance checks is intention-revealing: we never expect anything except one of these kinds of asynchronous messages to be on the input buffer outside of a query "request/response".

I've tested and can confirm this works with regular sockets and unix domain sockets.