### PR TITLE
Use Executor rather than ExecutorService

### DIFF
--- a/pg-core/src/java/org/pg/Config.java
+++ b/pg-core/src/java/org/pg/Config.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 public record Config(
         String user,
@@ -50,7 +50,7 @@ public record Config(
         Map<String, IProcessor> typeMap,
         boolean useUnixSocket,
         String unixSocketPath,
-        ExecutorService executor
+        Executor executor
 ) {
 
     public ConnType getConnType() {
@@ -103,7 +103,7 @@ public record Config(
         private final Map<String, IProcessor> typeMap = new HashMap<>();
         private boolean useUnixSocket = false;
         private String unixSocketPath = null;
-        private ExecutorService executor = Const.executor;
+        private Executor executor = Const.executor;
 
         public Builder(final String user, final String database) {
             this.user = Objects.requireNonNull(user, "User cannot be null");
@@ -330,7 +330,7 @@ public record Config(
         }
 
         @SuppressWarnings("unused")
-        public Builder executor(final ExecutorService executor) {
+        public Builder executor(final Executor executor) {
             this.executor = executor;
             return this;
         }

--- a/pg-core/src/java/org/pg/Connection.java
+++ b/pg-core/src/java/org/pg/Connection.java
@@ -1117,7 +1117,7 @@ public final class Connection implements AutoCloseable {
     }
 
     private void handlerCall (final IFn f, final Object arg) {
-        config.executor().submit(() -> {
+        config.executor().execute(() -> {
             f.invoke(arg);
         });
     }

--- a/pg-core/src/java/org/pg/Const.java
+++ b/pg-core/src/java/org/pg/Const.java
@@ -3,7 +3,7 @@ package org.pg;
 import clojure.lang.Agent;
 import org.pg.enums.SSLValidation;
 
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 public final class Const {
     public static final int PROTOCOL_VERSION = 196608;
@@ -39,5 +39,5 @@ public final class Const {
     public static final int POOL_SIZE_MAX = 8;
     public static final int POOL_EXPIRE_THRESHOLD_MS = 1000 * 60 * 5;
     public static final int POOL_BORROW_CONN_TIMEOUT_MS = 1000 * 15;
-    public static final ExecutorService executor = Agent.soloExecutor;
+    public static final Executor executor = Agent.soloExecutor;
 }


### PR DESCRIPTION
We don't need the lifecycle methods of ExecutorService, just the execute method of the superinterface Executor. This is more generic and allows easier extension, e.g. for a DirectExecutor than just immediately runs whatever it is passed.